### PR TITLE
Change cristo motor names to M1-M3 like the other bots

### DIFF
--- a/Robot Design/Robot_Cristo/Cristo.wbo
+++ b/Robot Design/Robot_Cristo/Cristo.wbo
@@ -27,7 +27,7 @@ DEF Cristo Robot {
       }
       device [
         RotationalMotor {
-          name "wheel3"
+          name "M3"
         }
       ]
       endPoint Solid {
@@ -68,7 +68,7 @@ DEF Cristo Robot {
       }
       device [
         RotationalMotor {
-          name "wheel1"
+          name "M1"
         }
       ]
       endPoint Solid {
@@ -100,7 +100,7 @@ DEF Cristo Robot {
       }
       device [
         RotationalMotor {
-          name "wheel2"
+          name "M2"
         }
       ]
       endPoint Solid {


### PR DESCRIPTION
Currently positions are unchanged. Probably a good idea to standardise those too. (front left = m1, front right = m2 etc)