### PR TITLE
Arena markers rotated

### DIFF
--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -2,8 +2,8 @@
 WorldInfo {
 }
 Viewpoint {
-  orientation -0.10238438298885476 -0.9674578639971838 -0.2313929979709807 2.3716107142131384
-  position -5.8669832126243735 3.616471007611013 -6.066888665989435
+  orientation 0.33246481952953133 -0.9314016676496985 -0.14818258087426103 5.456433700612629
+  position 6.9972994812935 3.16953523821157 7.1575439818618
 }
 TexturedBackgroundLight {
   texture "noon_park_empty"
@@ -232,6 +232,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 -2.154
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -260,6 +261,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 -1.436
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -288,6 +290,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 -0.718
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -316,6 +319,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 0
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -344,6 +348,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 0.718
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -372,6 +377,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 1.436
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -400,6 +406,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.8749 0.175 2.154
+      rotation 0 1 0 -1.5708003061004252
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -428,6 +435,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 2.154 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -456,6 +464,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 1.436 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -484,6 +493,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 0.718 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -512,6 +522,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation 0 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -540,6 +551,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -0.718 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -568,6 +580,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -1.436 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -596,6 +609,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.154 0.175 2.8749
+      rotation 0 1 0 -3.14159
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -624,6 +638,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 2.154
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -652,6 +667,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 1.436
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -680,6 +696,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 0.718
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -708,6 +725,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 0
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -736,6 +754,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 -0.718
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -764,6 +783,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 -1.436
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -792,6 +812,7 @@ DEF WALL Solid {
     }
     DEF WALL_MARKER Solid {
       translation -2.8749 0.175 -2.154
+      rotation 0 1 0 -4.712389693899574
       children [
         Shape {
           appearance DEF APP_FLOOR PBRAppearance {
@@ -1588,8 +1609,8 @@ Robot {
             }
           ]
           endPoint Solid {
-            translation 0.1999999877729786 0.0002686361091618171 -0.0003603015187829329
-            rotation -0.9999999953968224 4.2849467351666585e-05 8.585032564057782e-05 0.9344151591877564
+            translation 0.19999998777297853 0.00026863610916181706 -0.0003603015187829328
+            rotation -0.9999999953968224 4.284946735166655e-05 8.585032564057774e-05 0.9344151591877564
             children [
               DEF RIGHT_BLACK_CYLINDER_SHAPE Shape {
                 appearance PBRAppearance {
@@ -1771,7 +1792,7 @@ Robot {
           ]
           endPoint Solid {
             translation -0.19999998767113233 0.00026863721059561843 -0.00036030299207660306
-            rotation -0.999999995396832 -4.2849421713714726e-05 -8.58502344116959e-05 0.9344151521635337
+            rotation -0.999999995396832 -4.2849421713715e-05 -8.585023441169642e-05 0.9344151521635337
             children [
               DEF BLACK_CYLINDER_SHAPE Shape {
                 appearance PBRAppearance {
@@ -1948,8 +1969,8 @@ Robot {
             axis 0 1 0
           }
           endPoint Solid {
-            translation 3.567558609411397e-11 0.00029152609756950436 4.812113430210349e-07
-            rotation -0.9826105387155922 -0.18567856413792985 4.972993040880274e-06 3.864201805289567e-06
+            translation 3.567558609411397e-11 0.00029152609756950436 4.81211343021035e-07
+            rotation -0.9826105387155939 -0.1856785641379203 4.972993040880017e-06 3.864201805289567e-06
             children [
               DEF casterWheelRim HingeJoint {
                 jointParameters HingeJointParameters {
@@ -1957,8 +1978,8 @@ Robot {
                   anchor 0 -0.0521014 0.012843
                 }
                 endPoint Solid {
-                  translation -2.968546926221432e-09 -0.052112315544752326 0.011863874977601779
-                  rotation -1 -1.187454807027683e-10 9.781663462284222e-11 1.6144670885446237
+                  translation -2.9685469262214305e-09 -0.052112315544752326 0.011863874977601779
+                  rotation -1 -1.1874548070276828e-10 9.781663462284221e-11 1.6144670885446237
                   children [
                     DEF CASTER_WHEEL_RIM_SHAPE Shape {
                       appearance PBRAppearance {


### PR DESCRIPTION
Fixes a bug found in https://github.com/srobo/competition-simulator/pull/76#discussion_r432829561

Originally, the box dimensions were changed based on a marker's position in the arena. Now they all have the same dimensions but are rotated to have the front face pointing inside the arena.