### PR TITLE
Remove the camera delay

### DIFF
--- a/controllers/sr_controller/sr/robot/camera.py
+++ b/controllers/sr_controller/sr/robot/camera.py
@@ -170,6 +170,4 @@ class Camera:
             for face in token.visible_faces(is_2d=is_2d):
                 markers.append(Marker(face, marker_info, when))
 
-        time.sleep(0.1 * len(markers))
-
         return markers


### PR DESCRIPTION
This speeds up image processing. The multiplier was hard to get fine tuned. When teams start, the robot can see over 13 tokens, which slows things down massively! The calculations and processing are still _slightly_ intense so should delay things enough for us to be comfortable with it being realistic enough