### PR TITLE
Allow webots controller processes to be isolated using Firejail

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ On first run, the robot will execute an example program. On first run, this will
 │   └── worlds
 └── robot.py
 ```
+
+## Isolation
+
+In a competition environment, you may want to run the robot controllers in an isolated environment. To do this, webots has an integration with [Firejail](https://firejail.wordpress.com/).
+
+To allow webots to pass through controller code into the jails, it must be started using the [`script/webots-firejail`](./script/webots-firejail) script in the repo. Once started using this, all controllers will be run inside jails.

--- a/controllers/sr_controller/runtime.ini
+++ b/controllers/sr_controller/runtime.ini
@@ -1,0 +1,3 @@
+[environment variables with relative paths]
+
+FIREJAIL_PATH=$(SR_SIM_JAIL_PATHS)

--- a/script/webots-firejail
+++ b/script/webots-firejail
@@ -6,7 +6,7 @@ export WEBOTS_FIREJAIL_CONTROLLERS=1
 REPO_ROOT=$(dirname $0)/..
 
 # We want the Firejailed process to have access to the siblings of the
-# simulation directory because the  competitors code lives in sibling directories.
+# simulation directory because the competitors' code lives in sibling directories.
 REPO_PARENT=$REPO_ROOT/..
 
 # Used by `runtime.ini` to pass through all relevant files into jail

--- a/script/webots-firejail
+++ b/script/webots-firejail
@@ -3,7 +3,13 @@
 # Run webots controllers in jails
 export WEBOTS_FIREJAIL_CONTROLLERS=1
 
+REPO_ROOT=$(dirname $0)/..
+
+# We want the Firejailed process to have access to the siblings of the
+# simulation directory because the  competitors code lives in sibling directories.
+REPO_PARENT=$REPO_ROOT/..
+
 # Used by `runtime.ini` to pass through all relevant files into jail
-export SR_SIM_JAIL_PATHS=$(realpath -e ${PWD}/$(dirname $0)/../../)
+export SR_SIM_JAIL_PATHS=$(realpath -e $REPO_PARENT)
 
 exec webots $@

--- a/script/webots-firejail
+++ b/script/webots-firejail
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Run webots controllers in jails
+export WEBOTS_FIREJAIL_CONTROLLERS=1
+
+# Used by `runtime.ini` to pass through all relevant files into jail
+export SR_SIM_JAIL_PATHS=$(realpath -e ${PWD}/$(dirname $0)/../../)
+
+exec webots $@

--- a/script/webots-firejail
+++ b/script/webots-firejail
@@ -12,4 +12,4 @@ REPO_PARENT=$REPO_ROOT/..
 # Used by `runtime.ini` to pass through all relevant files into jail
 export SR_SIM_JAIL_PATHS=$(realpath -e $REPO_PARENT)
 
-exec webots $@
+exec webots "$@"


### PR DESCRIPTION
The firejail integration code is at https://github.com/cyberbotics/webots/blob/0275bbe15f7c1f7dc34ea6b9c872e019419e4cfa/src/webots/control/WbController.cpp#L238, and is the only real documentation for it.

The hack around `$SR_SIM_JAIL_PATHS` is because webots currently uses the **process** environment for resolving variables in `runtime.ini` rather than the **controller** environment. I'll probably push a fix upstream at some point.

The jail issues could be resolved by implementing jailing outselves, but I didn't want to do that really, and this way keeps the implementation entirely inside webots itself!