### PR TITLE
Fixes gripper jumping

### DIFF
--- a/controllers/sr_controller/sr/robot/motor_devices.py
+++ b/controllers/sr_controller/sr/robot/motor_devices.py
@@ -35,7 +35,7 @@ class LinearMotor(MotorBase):
         self._set_speed(speed)
         motor = self.webot_motor
         if speed < 0:
-            motor.setPosition(motor.getMinPosition())
+            motor.setPosition(motor.getMinPosition()+0.01)
         else:
             motor.setPosition(motor.getMaxPosition())
         motor.setVelocity(abs(speed))

--- a/controllers/sr_controller/sr/robot/motor_devices.py
+++ b/controllers/sr_controller/sr/robot/motor_devices.py
@@ -35,7 +35,7 @@ class LinearMotor(MotorBase):
         self._set_speed(speed)
         motor = self.webot_motor
         if speed < 0:
-            motor.setPosition(motor.getMinPosition()+0.01)
+            motor.setPosition(motor.getMinPosition() + 0.01)
         else:
             motor.setPosition(motor.getMaxPosition())
         motor.setVelocity(abs(speed))


### PR DESCRIPTION
Fixes #95 - Gripper wraps around when fully shut.

Modification of arm physics models didn't yield a solution, the issue of gripper jumping appears to only occur when the fingers are trying to set their positions to 0., adding the 1cm offset appears to fix. 