### PR TITLE
Fix boolean logic around continuing step

### DIFF
--- a/controllers/sr_controller/sr/robot/robot.py
+++ b/controllers/sr_controller/sr/robot/robot.py
@@ -61,7 +61,7 @@ class Robot(object):
         """
         Run a webots step of the given duration in milliseconds.
 
-        Returns whether or not Webots is about to terminate the simulation.
+        Returns whether or not the simulation should continue (ie is webots terminating).
         """
 
         with self._step_lock:

--- a/controllers/sr_controller/sr/robot/robot.py
+++ b/controllers/sr_controller/sr/robot/robot.py
@@ -61,7 +61,8 @@ class Robot(object):
         """
         Run a webots step of the given duration in milliseconds.
 
-        Returns whether or not the simulation should continue (ie is webots terminating).
+        Returns whether or not the simulation should continue (based on
+        Webots telling us whether or not the simulation is about to end).
         """
 
         with self._step_lock:

--- a/controllers/sr_controller/sr/robot/robot.py
+++ b/controllers/sr_controller/sr/robot/robot.py
@@ -70,7 +70,7 @@ class Robot(object):
             # that mode, Webots returns -1 from step to indicate that the
             # simulation is terminating, or 0 otherwise.
             result = self.webot.step(duration_ms)
-            return result == -1
+            return result != -1
 
     def webot_run_robot(self):
         while self.webots_step_and_should_continue(TIME_STEP):


### PR DESCRIPTION
Fix issue introduced in #110 

We want to continue when the application *isn't* terminating.


> If the synchronization field is TRUE, this function always returns 0 (or -1 to indicate termination).
> https://www.cyberbotics.com/doc/reference/robot#wb_robot_step