### PR TITLE
Use symlinked controllers to provide a distinct prefix in the console

### DIFF
--- a/controllers/sr_controller_0/sr_controller_0.py
+++ b/controllers/sr_controller_0/sr_controller_0.py
@@ -1,0 +1,1 @@
+../sr_controller/sr_controller.py

--- a/controllers/sr_controller_1/sr_controller_1.py
+++ b/controllers/sr_controller_1/sr_controller_1.py
@@ -1,0 +1,1 @@
+../sr_controller/sr_controller.py

--- a/controllers/sr_controller_2/sr_controller_2.py
+++ b/controllers/sr_controller_2/sr_controller_2.py
@@ -1,0 +1,1 @@
+../sr_controller/sr_controller.py

--- a/controllers/sr_controller_3/sr_controller_3.py
+++ b/controllers/sr_controller_3/sr_controller_3.py
@@ -1,0 +1,1 @@
+../sr_controller/sr_controller.py

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -1306,24 +1306,27 @@ SRRobot {
   translation -2.375 0 -2.375
   rotation 0 1 0 3.926
   model "Robot0"
-  controller "sr_controller"
+  controller "sr_controller_0"
   flagColour 0 1 0
 }
 SRRobot {
   translation 2.375 0 -2.375
   rotation 0 1 0 2.266
   model "Robot1"
+  controller "sr_controller_1"
   flagColour 1 0.375 0
 }
 SRRobot {
   translation 2.375 0 2.375
   rotation 0 1 0 0.875
   model "Robot2"
+  controller "sr_controller_2"
   flagColour 1 0 1
 }
 SRRobot {
   translation -2.375 0 2.375
   rotation 0 1 0 -0.875
   model "Robot3"
+  controller "sr_controller_3"
   flagColour 1 1 0
 }


### PR DESCRIPTION
The idea here is that each robot has its own controller, but in the repo they share the same source code.

In theory at least, symlinks are cross platform (ish) having been [part of Windows 10](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/) for a number of years now. Obviously it's possible that some users are using older versions of Windows, though hopefully not many.

The main potential issue I see here is whether the symlinks survive being included in the archive which GitHub creates for us. This probably just needs someone to test unzipping the archive of this branch on Windows 10.

I have checked that this works for a robot.py in the default location (for zone 0) and in the zone-1 location.