### PR TITLE
Make robots their flag colour

### DIFF
--- a/protos/Robot_Echo/SRRobot.proto
+++ b/protos/Robot_Echo/SRRobot.proto
@@ -394,7 +394,7 @@ PROTO SRRobot [
                 }
                 DEF RIM_SHAPE Shape {
                   appearance PBRAppearance {
-                    baseColor 0.98 0.66 0.02
+                    baseColor IS flagColour
                     roughness 0.3
                     metalness 0
                   }
@@ -576,7 +576,7 @@ PROTO SRRobot [
                 }
                 DEF RIM_SHAPE Shape {
                   appearance PBRAppearance {
-                    baseColor 0.98 0.66 0.02
+                    baseColor IS flagColour
                     roughness 0.3
                     metalness 0
                   }
@@ -1037,7 +1037,7 @@ PROTO SRRobot [
                 children [
                   DEF body Shape {
                     appearance PBRAppearance {
-                      baseColor 0.98 0.66 0.02
+                      baseColor IS flagColour
                       roughness 0.3
                       metalness 0
                     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6527489/84573076-460a4800-ad96-11ea-8dc7-2992916a4a69.png)

This makes them easier to see through the competition. Left the flags in because it's easier, and means not changing the rules about their existence