### PR TITLE
Ban accidental usage of 'print'

### DIFF
--- a/controllers/sr_controller/sr/robot/game.py
+++ b/controllers/sr_controller/sr/robot/game.py
@@ -10,7 +10,7 @@ def game_over():
     ==========
     Game Over!
     ==========
-    """).strip())
+    """).strip())  # noqa:T001
     _thread.interrupt_main()
 
 

--- a/controllers/sr_controller/sr/robot/robot.py
+++ b/controllers/sr_controller/sr/robot/robot.py
@@ -47,7 +47,7 @@ class Robot:
         self._initialised = True
 
     def display_info(self):
-        print("Robot Initialized. Zone: {zone}. Mode: {mode}.".format(
+        print("Robot Initialized. Zone: {zone}. Mode: {mode}.".format(  # noqa:T001
             zone=self.zone,
             mode=self.mode,
         ))

--- a/controllers/sr_controller/sr/robot/vision/convert.py
+++ b/controllers/sr_controller/sr/robot/vision/convert.py
@@ -75,7 +75,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
-    print(rotation_matrix_from_axis_and_angle(WebotsOrientation(
+    print(rotation_matrix_from_axis_and_angle(WebotsOrientation(  # noqa:T001
         args.x,
         args.y,
         args.z,

--- a/script/linting/requirements.txt
+++ b/script/linting/requirements.txt
@@ -4,6 +4,7 @@ flake8-commas
 flake8-comprehensions
 flake8-debugger
 flake8-isort
+flake8-print
 flake8-mutable
 flake8-todo
 flake8-tuple

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,8 @@ ignore =
 
 per-file-ignores =
     # This is the example file, where we encourage use of `import *`.
-    controllers/example_controller/example_controller.py:F403,F405
+    # It also needs to be able to print easily.
+    controllers/example_controller/example_controller.py:F403,F405,T001
     # Entry point file which needs to be able to print stuff
     controllers/sr_controller/sr_controller.py:T001
     # Ignore stub-ness in our stub webots.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ ignore =
 per-file-ignores =
     # This is the example file, where we encourage use of `import *`.
     controllers/example_controller/example_controller.py:F403,F405
+    # Entry point file which needs to be able to print stuff
+    controllers/sr_controller/sr_controller.py:T001
     # Ignore stub-ness in our stub webots.
     stub-webots/controller.py:E704
 


### PR DESCRIPTION
Aims to avoid `print` statements from debugging making their way into `master`.