### PR TITLE
Pass the webots object around less

### DIFF
--- a/controllers/sr_controller/sr/robot/camera.py
+++ b/controllers/sr_controller/sr/robot/camera.py
@@ -146,8 +146,7 @@ class Marker:
 
 class Camera:
     def __init__(self, webot):
-        self.webot = webot
-        self.camera = self.webot.getCamera("camera")
+        self.camera = webot.getCamera("camera")
         self.camera.enable(TIME_STEP)
         self.camera.recognitionEnable(TIME_STEP)
 

--- a/controllers/sr_controller/sr/robot/motor.py
+++ b/controllers/sr_controller/sr/robot/motor.py
@@ -8,14 +8,14 @@ SPEED_MAX = 100
 
 def init_motor_array(webot):
     return [
-        Motor(0, webot, [
+        Motor(
             Wheel(webot, 'left wheel'),
             Wheel(webot, 'right wheel'),
-        ]),
-        Motor(1, webot, [
+        ),
+        Motor(
             LinearMotor(webot, 'lift motor'),
             Gripper(webot, 'left finger motor|right finger motor'),
-        ]),
+        ),
     ]
 
 
@@ -37,18 +37,14 @@ def translate(sr_speed_val, sr_motor):
 class Motor:
     """A motor"""
 
-    def __init__(self, board_id, webot, sr_motors):
-        self.board_id = board_id
-        self.m0 = MotorChannel(0, webot, board_id, sr_motors[0])
-        self.m1 = MotorChannel(1, webot, board_id, sr_motors[1])
-        self.webot = webot
+    def __init__(self, m0, m1):
+        self.m0 = MotorChannel(0, m0)
+        self.m1 = MotorChannel(1, m1)
 
 
 class MotorChannel:
-    def __init__(self, channel, webot, board_id, sr_motor):
+    def __init__(self, channel, sr_motor):
         self.channel = channel
-        self.webot = webot
-        self.board_id = board_id
         # Private shadow of use_brake
         # self._use_brake = True # TODO create new thread for non-braking slowdown
 

--- a/controllers/sr_controller/sr/robot/motor_devices.py
+++ b/controllers/sr_controller/sr/robot/motor_devices.py
@@ -1,15 +1,8 @@
 class MotorBase:
     def __init__(self, webot, motor_name):
-        self.webot = webot
         self.motor_name = motor_name
-        self.webot_motor = self.webot.getMotor(motor_name)
-        if self.webot_motor is None:
-            return
+        self.webot_motor = webot.getMotor(motor_name)
         self.max_speed = self.webot_motor.getMaxVelocity()
-
-    def _set_speed(self, speed):
-        if self.webot_motor is None:
-            return
 
 
 class Wheel(MotorBase):
@@ -20,7 +13,6 @@ class Wheel(MotorBase):
         self.webot_motor.setVelocity(0)
 
     def set_speed(self, speed):
-        self._set_speed(speed)
         self.webot_motor.setVelocity(speed)
 
 
@@ -32,7 +24,6 @@ class LinearMotor(MotorBase):
         self.webot_motor.setVelocity(0)
 
     def set_speed(self, speed):
-        self._set_speed(speed)
         motor = self.webot_motor
         if speed < 0:
             motor.setPosition(motor.getMinPosition() + 0.01)

--- a/controllers/sr_controller/sr/robot/ruggeduino.py
+++ b/controllers/sr_controller/sr/robot/ruggeduino.py
@@ -22,15 +22,14 @@ def init_ruggeduino_array(webot):
 
     digital_array = [Microswitch(webot, name) for name in switch_names]
 
-    return [Ruggeduino(webot, analogue_array, digital_array)]
+    return [Ruggeduino(analogue_array, digital_array)]
 
 
 class Ruggeduino:
 
     DIGITAL_PIN_OFFSET = 2  # Exclude pins 0 and 1 as they are used for USB serial comms
 
-    def __init__(self, webot, analogue_array, digital_array):
-        self.webot = webot
+    def __init__(self, analogue_array, digital_array):
         self.analogue_array = analogue_array
         self.digital_array = digital_array
 

--- a/controllers/sr_controller/sr/robot/sensor_devices.py
+++ b/controllers/sr_controller/sr/robot/sensor_devices.py
@@ -3,21 +3,13 @@ from sr.robot.settings import TIME_STEP
 from sr.robot.randomizer import add_jitter
 
 
-class SensorBase:
-
-    def __init__(self, webot, sensor_name):
-        self.webot = webot
-        self.sensor_name = sensor_name
-
-
-class DistanceSensor(SensorBase):
+class DistanceSensor:
 
     LOWER_BOUND = 0
     UPPER_BOUND = 0.3
 
     def __init__(self, webot, sensor_name):
-        super().__init__(webot, sensor_name)
-        self.webot_sensor = self.webot.getDistanceSensor(self.sensor_name)
+        self.webot_sensor = webot.getDistanceSensor(sensor_name)
         self.webot_sensor.enable(TIME_STEP)
 
     def __get_scaled_distance(self):
@@ -37,11 +29,10 @@ class DistanceSensor(SensorBase):
         )
 
 
-class Microswitch(SensorBase):
+class Microswitch:
 
     def __init__(self, webot, sensor_name):
-        super().__init__(webot, sensor_name)
-        self.webot_sensor = self.webot.getTouchSensor(self.sensor_name)
+        self.webot_sensor = webot.getTouchSensor(sensor_name)
         self.webot_sensor.enable(TIME_STEP)
 
     def read_value(self):


### PR DESCRIPTION
Taken from #96.

Stop passing the webots object where it's not needed, and stop setting it on `self`. Mostly just for cleanup reasons.