### PR TITLE
Prevent floating point rounding errors causing math domain errors

### DIFF
--- a/modules/sr/robot/vision/tests.py
+++ b/modules/sr/robot/vision/tests.py
@@ -345,6 +345,13 @@ class VectorTests(unittest.TestCase):
             (180, Vector((1, 0, 0)), Vector((-1, 0, 0))),
             (90, Vector((1, 0, 0)), Vector((0, 1, 0))),
             (90, Vector((2, 0, 0)), Vector((0, 0, 2))),
+            (
+                # Regression test for input which manages to be out of bounds
+                # for cos theta due to floating point rounding errors.
+                180,
+                Vector((-0.1757748978918965, -0.027978574520328252, -0.09121614242503248)),
+                Vector((0.8788744894594824, 0.13989287260164124, 0.4560807121251624)),
+            ),
         )
 
         for case in cases:

--- a/modules/sr/robot/vision/vectors.py
+++ b/modules/sr/robot/vision/vectors.py
@@ -156,6 +156,12 @@ def angle_between(vec_a: Vector, vec_b: Vector) -> float:
     dp = dot_product(vec_a, vec_b)
     mod_ab = vec_a.magnitude() * vec_b.magnitude()
     cos_theta = dp / mod_ab
+
+    if abs(cos_theta) > 1:
+        # Round small floating point rounding errors to avoid a math domain
+        # error from math.acos, without masking genuine errors.
+        cos_theta = round(cos_theta, 15)
+
     theta_rads = math.acos(cos_theta)
     theta_degrees = math.degrees(theta_rads)
     return theta_degrees


### PR DESCRIPTION
This introduces a rounding which should have minimal effect on valid inputs, but which will still error for wildly invalid ones.

Fixes https://github.com/srobo/competition-simulator/issues/107.