### PR TITLE
Handle non-unicode recognition object model names

### DIFF
--- a/modules/sr/robot/camera.py
+++ b/modules/sr/robot/camera.py
@@ -156,7 +156,7 @@ class Camera:
 
         for recognition_object in self.camera.getRecognitionObjects():
             marker_info = parse_marker_info(
-                recognition_object.get_model().decode(),
+                recognition_object.get_model().decode(errors='replace'),
             )
             if marker_info:
                 object_infos[recognition_object] = marker_info


### PR DESCRIPTION
Use `'replace'` over `'ignore'` so that we don't accidentally match a name which happens to contain only our model names plus some invalid characters.

Fixes https://github.com/srobo/competition-simulator/issues/115.