### PR TITLE
Execute the competitor code inline rather than as a subprocess

### DIFF
--- a/controllers/sr_controller/sr_controller.py
+++ b/controllers/sr_controller/sr_controller.py
@@ -2,7 +2,6 @@ import os
 import sys
 import subprocess
 from shutil import copyfile
-from typing import Dict
 from pathlib import Path
 
 # Root directory of the SR webots simulator (equivalent to the root of the git repo)
@@ -150,9 +149,7 @@ def main():
     # Swith to running the competitor code
     reconfigure_environment(robot_file)
 
-    robot_globals = {}  # type: Dict[str, object]
-
-    exec(robot_file.read_text(), robot_globals, robot_globals)
+    exec(robot_file.read_text(), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This aims to avoid an issue on Windows where the child processes become zombies after the parent is killed forcefully by Webots.

Replaces #143.
Fixes https://github.com/srobo/competition-simulator/issues/114.