### PR TITLE
Avoid launching two webots threads if you use Robot.setup

### DIFF
--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -33,19 +33,19 @@ class Robot:
 
         if init:
             self.init()
-            self.display_info()
             self.wait_start()
             if self.mode == "comp":
                 stop_after_delay()
 
     @classmethod
     def setup(cls):
-        return cls()
+        return cls(init=False)
 
     def init(self) -> None:
         self.webots_init()
         self._init_devs()
         self._initialised = True
+        self.display_info()
 
     def _get_user_code_info(self) -> Optional[str]:
         user_version_path = path.join(self.usbkey, '.user-rev')


### PR DESCRIPTION
This more closely matches the on-robot API by not calling the init logic immediately when `Robot.setup()` is called.