### PR TITLE
Attempt to fix the Webots access violations reported in the forums

### DIFF
--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -134,7 +134,8 @@ class Robot:
         self.ruggeduinos = ruggeduino.init_ruggeduino_array(self.webot)
 
     def _init_camera(self) -> None:
-        self.camera = camera.Camera(self.webot)
+        # See comment in Camera.see for why we need to pass the step lock here.
+        self.camera = camera.Camera(self.webot, self._step_lock)
         self.see = self.camera.see
 
     def time(self) -> float:


### PR DESCRIPTION
As reported [in the forums](https://studentrobotics.org/forum/viewtopic.php?f=10&t=94&start=10), it's possible to get an access violation from within Webots.

I was able to get a similar error locally (by running that team's code) which indicated the source of the error being within the `WbCamreaRecognitionObject_get_model` function, though I suspect that any of the `CameraRecognitionObject` methods could cause this.

From reading through the Webots source for the camera (start around https://github.com/cyberbotics/webots/blob/f704595a9c/src/lib/Controller/api/camera.c#L550) there's a whole bunch of locking apparently going on there, which seems to confirm the theory that we're using objects after they've been cleaned up.

In any case, I was able to reliably reproduce the issue with robot code like this:
``` python
from sr.robot import Robot
R = Robot()
while True:
    R.see()
```

The fix therefore is to pass the step-lock which we already have (currently used for implementing the `Robot.sleep` method safely) into the `Camera` so that the camera can safely do its work within the confines of a single time-step.