### PR TITLE
Introduce a separate robot class with manual timestep control

### DIFF
--- a/modules/sr/robot/__init__.py
+++ b/modules/sr/robot/__init__.py
@@ -1,5 +1,5 @@
 import sr.robot._version_check  # noqa
-from sr.robot.robot import Robot
+from sr.robot.robot import Robot, LegacyRobot
 from sr.robot.camera import (
     MarkerType,
     MARKER_ARENA,
@@ -10,6 +10,7 @@ from sr.robot.camera import (
 __all__ = (
     'Robot',
     'MarkerType',
+    'LegacyRobot',
     'MARKER_ARENA',
     'MARKER_TOKEN_GOLD',
     'MARKER_TOKEN_SILVER',

--- a/modules/sr/robot/__init__.py
+++ b/modules/sr/robot/__init__.py
@@ -1,5 +1,5 @@
 import sr.robot._version_check  # noqa
-from sr.robot.robot import Robot, LegacyRobot
+from sr.robot.robot import ManualTimestepRobot, AutomaticTimestepRobot as Robot
 from sr.robot.camera import (
     MarkerType,
     MARKER_ARENA,
@@ -10,8 +10,8 @@ from sr.robot.camera import (
 __all__ = (
     'Robot',
     'MarkerType',
-    'LegacyRobot',
     'MARKER_ARENA',
     'MARKER_TOKEN_GOLD',
+    'ManualTimestepRobot',
     'MARKER_TOKEN_SILVER',
 )

--- a/modules/sr/robot/camera.py
+++ b/modules/sr/robot/camera.py
@@ -155,10 +155,12 @@ class Marker:
 
 class Camera:
     def __init__(self, webot: Robot, lock: threading.Lock) -> None:
+        self._webot = webot
+        self._timestep = int(webot.getBasicTimeStep())
+
         self.camera = webot.getCamera("camera")
-        timestep = int(webot.getBasicTimeStep())
-        self.camera.enable(timestep)
-        self.camera.recognitionEnable(timestep)
+        self.camera.enable(self._timestep)
+        self.camera.recognitionEnable(self._timestep)
 
         self._lock = lock
 
@@ -175,6 +177,7 @@ class Camera:
         # processing. The objects which we pass back to the caller are safe to
         # use because they don't refer to Webots' objects at all.
         with self._lock:
+            self._webot.step(self._timestep)
             return self._see()
 
     def _see(self) -> List[Marker]:

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -9,8 +9,13 @@ from sr.robot import motor, camera, ruggeduino
 from controller import Robot as WebotsRobot  # isort:skip
 
 
-class Robot:
-    """Class for initialising and accessing robot hardware"""
+class ManualTimestepRobot:
+    """
+    Class for initialising and accessing robot hardware.
+
+    This robot requires that the consumer manage the progession of time manually
+    by calling the `sleep` method.
+    """
 
     def __init__(self, quiet: bool = False, init: bool = True) -> None:
         self._initialised = False
@@ -142,9 +147,17 @@ class Robot:
         self.webots_step_and_should_continue(duration_ms)
 
 
-class LegacyRobot(Robot):
+class AutomaticTimestepRobot(ManualTimestepRobot):
     """
-    Robot class which preserves the original somewhat jittery Robot behaviour.
+    Robot class which preserves the original automatic time-advancing behaviour.
+
+    This class launches a background thread which advances the timestep in a
+    tight loop. This is somewhat more convenient to program against because it
+    does not rely on the `sleep` method being called in order for time to
+    advance. However as a result the timestep is considerably less predictable
+    which can result in unexpected robot behaviours.
+
+    The `sleep` method of this class is still available and is thread-safe.
     """
 
     def init(self) -> None:

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -11,7 +11,7 @@ from controller import Robot as WebotsRobot  # isort:skip
 
 class ManualTimestepRobot:
     """
-    Class for initialising and accessing robot hardware.
+    Primary API for access to robot parts.
 
     This robot requires that the consumer manage the progession of time manually
     by calling the `sleep` method.


### PR DESCRIPTION
This allows teams to avoid a variety of timing issues which introduce randomness into the robot behaviours that we don't want. Notably this appears to fix the issues [reported by MAI in the forums](https://www.studentrobotics.org/forum/viewtopic.php?f=9&t=106).

At least the camera needs to have a time step explicitly forced before it can provide useful information, so we handle that in
the Camera itself. This feels reasonable in any cases as we know that a real camera takes a non-zero amount of time to respond. Simple testing suggests that other sensors may not be so affected, though it is hard to know whether that is a natural consequence of them only being used after several timesteps have been done as a matter of course.

----

This is backwards compatible, however when using the new `ManualTimestepRobot` class `time.sleep` alone is no longer suitable for waiting for things to happen -- teams _must_ use `Robot.sleep` instead.
We will need to document both that this new alternative exists and how to use it.