### PR TITLE
Ensure that all sleep times do actually advance the clock

### DIFF
--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -87,6 +87,11 @@ class Robot:
         Webots telling us whether or not the simulation is about to end).
         """
 
+        if duration_ms <= 0:
+            raise ValueError(
+                "Duration must be greater than zero, not {!r}".format(duration_ms),
+            )
+
         with self._step_lock:
             # We use Webots in synchronous mode (specifically
             # `synchronization` is left at its default value of `TRUE`). In
@@ -151,7 +156,7 @@ class Robot:
             raise ValueError('sleep length must be non-negative')
 
         # Ensure the time delay is a valid step increment
-        n_steps = int((secs * 1000) // self._timestep)
+        n_steps = int((secs * 1000) // self._timestep) or 1
         duration_ms = n_steps * self._timestep
 
         # We're in the main thread here, so we don't really need to do any

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -1,3 +1,4 @@
+import math
 import time
 from os import path, environ
 from typing import Optional
@@ -155,8 +156,9 @@ class Robot:
         if secs < 0:
             raise ValueError('sleep length must be non-negative')
 
-        # Ensure the time delay is a valid step increment
-        n_steps = int((secs * 1000) // self._timestep) or 1
+        # Ensure the time delay is a valid step increment, while also ensuring
+        # that small values remain nonzero.
+        n_steps = math.ceil((secs * 1000) / self._timestep)
         duration_ms = n_steps * self._timestep
 
         # We're in the main thread here, so we don't really need to do any


### PR DESCRIPTION
Teams don't know what the smallest timestep is, so this ensures that all attempts to sleep do sleep for at least some time. This also avoids issues where the simulation doesn't run because no steps are being taken.

This only really applies when not running the background thread, however as that's the plan anyway (see #158) this seems useful.