### PR TITLE
Change to release on Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,8 @@ jobs:
 
   release:
     docker:
-      - image: circleci/python:3.5
+      # Release on 3.6+ so we can have non-strict Path.resolve()
+      - image: circleci/python:3.6
     steps:
       # Note: we run the release on *all* tags. If we change to creating
       # releases here (or anything more involved) we should review whether or


### PR DESCRIPTION
It turns out that in Python 3.5 (and lower) `pathlib.Path.resolve()` will check for the existence of a file as part of its resolution.
This changed in Python 3.6 (with an argument to get the old behaviour back). We want the new default behaviour.