### PR TITLE
Correct the tidying of sys.path prior to running user code

### DIFF
--- a/controllers/sr_controller/sr_controller.py
+++ b/controllers/sr_controller/sr_controller.py
@@ -134,14 +134,9 @@ def reconfigure_environment(robot_file: Path) -> None:
     """
 
     # Remove ourselves from the path and insert the competitor code
-    sys.path[:1] = [
-        # User code first
-        str(robot_file.parent),
-        # Then the SR module
-        str(ROOT / "modules"),
-        # Then everything else which was on the path, except for the
-        # `sr_controller` directory (which was previously first).
-    ]
+    sys.path.pop(0)
+    sys.path.insert(0, str(ROOT / "modules"))
+    sys.path.insert(0, str(robot_file.parent))
 
     os.chdir(str(robot_file.parent))
 

--- a/controllers/sr_controller/sr_controller.py
+++ b/controllers/sr_controller/sr_controller.py
@@ -134,9 +134,14 @@ def reconfigure_environment(robot_file: Path) -> None:
     """
 
     # Remove ourselves from the path and insert the competitor code
-    sys.path.pop()
-    sys.path.insert(0, str(ROOT / "modules"))
-    sys.path.insert(0, str(robot_file.parent))
+    sys.path[:1] = [
+        # User code first
+        str(robot_file.parent),
+        # Then the SR module
+        str(ROOT / "modules"),
+        # Then everything else which was on the path, except for the
+        # `sr_controller` directory (which was previously first).
+    ]
 
     os.chdir(str(robot_file.parent))
 


### PR DESCRIPTION
`.pop()` pops off the end of the list, not the start. Ooops.

Fixes https://github.com/srobo/competition-simulator/issues/167.

Suggest that we release this as `0.3.2` once merged.