### PR TITLE
Also lint & typecheck the scripts we have

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
 
             # Ignore TODOs on CI, for now, even though we do want them
             # highlighted in development.
-            ./script/linting/lint --extend-ignore=T000 $SCRIPTS
+            ./script/linting/lint $SCRIPTS --extend-ignore=T000
 
   typecheck:
     <<: *parametrised-python-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,10 @@ jobs:
             source venv/bin/activate
 
             # Only check the scripts when not on Python 3.5
-            SCRIPTS=$(python3 --version | grep -vF '3.5.' > /dev/null && find script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+            if python3 --version | grep -vF '3.5.' > /dev/null
+            then
+                SCRIPTS=$(find script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+            fi
 
             # Ignore TODOs on CI, for now, even though we do want them
             # highlighted in development.
@@ -118,7 +121,10 @@ jobs:
             source venv/bin/activate
 
             # Only check the scripts when not on Python 3.5
-            SCRIPTS=$(python3 --version | grep -vF '3.5.' > /dev/null && find script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+            if python3 --version | grep -vF '3.5.' > /dev/null
+            then
+                SCRIPTS=$(find script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+            fi
 
             ./script/typing/check $SCRIPTS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,13 @@ jobs:
           name: Run Flake8
           command: |
             source venv/bin/activate
+
+            # Only check the scripts when not on Python 3.5
+            SCRIPTS=$(python3 --version | grep -vF '3.5.' > /dev/null && find script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+
             # Ignore TODOs on CI, for now, even though we do want them
             # highlighted in development.
-            ./script/linting/lint --extend-ignore=T000
+            ./script/linting/lint --extend-ignore=T000 $SCRIPTS
 
   typecheck:
     <<: *parametrised-python-executor
@@ -112,7 +116,11 @@ jobs:
           name: Run Mypy
           command: |
             source venv/bin/activate
-            ./script/typing/check
+
+            # Only check the scripts when not on Python 3.5
+            SCRIPTS=$(python3 --version | grep -vF '3.5.' > /dev/null && find script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+
+            ./script/typing/check $SCRIPTS
 
   build:
     docker:

--- a/script/check
+++ b/script/check
@@ -2,13 +2,15 @@
 
 cd $(dirname $0)/..
 
+SCRIPTS=$(find $ROOT/script -type f | grep -vP "/(linting/|testing/|typing/|check$)")
+
 ./script/testing/test
 result=$?
 
-./script/linting/lint
+./script/linting/lint $SCRIPTS
 result=$((result | $?))
 
-./script/typing/check
+./script/typing/check $SCRIPTS
 result=$((result | $?))
 
 exit $result


### PR DESCRIPTION
These need a little special handling since we don't want to check these on Python 3.5 (the scripts already use 3.6+ features).

For the moment we assume most actual developers will have Python 3.6+ anyway, so `script/check` just assumes it should check these files regardless.