### PR TITLE
Replace string parsing with tuple literal

### DIFF
--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -17,7 +17,7 @@ def init_motor_array(webot: Robot) -> 'List[Motor]':
         ),
         Motor(
             LinearMotor(webot, 'lift motor'),
-            Gripper(webot, 'left finger motor|right finger motor'),
+            Gripper(webot, ('left finger motor', 'right finger motor')),
         ),
     ]
 

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from controller import Robot
 
 
@@ -37,12 +39,10 @@ class LinearMotor(MotorBase):
 
 class Gripper(MotorBase):
 
-    def __init__(self, webot: Robot, motor_name: str) -> None:
+    def __init__(self, webot: Robot, motor_names: Tuple[str, str]) -> None:
         self.webot = webot
-        names = motor_name.split("|")
         self.gripper_motors = [
-            LinearMotor(self.webot, names[0]),
-            LinearMotor(self.webot, names[1]),
+            LinearMotor(self.webot, name) for name in motor_names
         ]
         self.max_speed = self.gripper_motors[0].max_speed
 


### PR DESCRIPTION
This simplifies the code as well as allowing the type signature to specify exactly how many entries should be present.