### PR TITLE
Promote the ManualTimestepRobot

### DIFF
--- a/modules/sr/robot/__init__.py
+++ b/modules/sr/robot/__init__.py
@@ -1,5 +1,5 @@
 import sr.robot._version_check  # noqa
-from sr.robot.robot import ManualTimestepRobot, AutomaticTimestepRobot as Robot
+from sr.robot.robot import Robot
 from sr.robot.camera import (
     MarkerType,
     MARKER_ARENA,
@@ -12,6 +12,5 @@ __all__ = (
     'MarkerType',
     'MARKER_ARENA',
     'MARKER_TOKEN_GOLD',
-    'ManualTimestepRobot',
     'MARKER_TOKEN_SILVER',
 )

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -1,8 +1,7 @@
 import math
-import time
 from os import path, environ
 from typing import Optional
-from threading import Lock, Thread
+from threading import Lock
 
 from sr.robot import motor, camera, ruggeduino
 
@@ -10,7 +9,7 @@ from sr.robot import motor, camera, ruggeduino
 from controller import Robot as WebotsRobot  # isort:skip
 
 
-class ManualTimestepRobot:
+class Robot:
     """
     Primary API for access to robot parts.
 
@@ -152,38 +151,3 @@ class ManualTimestepRobot:
         # cleanup if Webots tells us the simulation is terminating. When webots
         # kills the process all the proper tidyup will happen anyway.
         self.webots_step_and_should_continue(duration_ms)
-
-
-class AutomaticTimestepRobot(ManualTimestepRobot):
-    """
-    Robot class which preserves the original automatic time-advancing behaviour.
-
-    This class launches a background thread which advances the timestep in a
-    tight loop. This is somewhat more convenient to program against because it
-    does not rely on the `sleep` method being called in order for time to
-    advance. However as a result the timestep is considerably less predictable
-    which can result in unexpected robot behaviours.
-
-    The `sleep` method of this class is still available and is thread-safe.
-    """
-
-    def init(self) -> None:
-        self.webots_init()
-        super().init()
-
-    def webots_init(self) -> None:
-        # Create a thread which will advance time in the background, so that the
-        # competitors' code can ignore the fact that it is actually running in a
-        # simulation.
-        t = Thread(
-            target=self.webot_run_robot,
-            # Ensure our background thread alone won't keep the controller
-            # process runnnig.
-            daemon=True,
-        )
-        t.start()
-        time.sleep(self._timestep / 1000)
-
-    def webot_run_robot(self):
-        while self.webots_step_and_should_continue(self._timestep):
-            pass

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -147,7 +147,7 @@ class Robot:
         n_steps = math.ceil((secs * 1000) / self._timestep)
         duration_ms = n_steps * self._timestep
 
-        # We're in the main thread here, so we don't really need to do any
-        # cleanup if Webots tells us the simulation is terminating. When webots
-        # kills the process all the proper tidyup will happen anyway.
+        # Assume that we're in the main thread here, so we don't really need to
+        # do any cleanup if Webots tells us the simulation is terminating. When
+        # webots kills the process all the proper tidyup will happen anyway.
         self.webots_step_and_should_continue(duration_ms)


### PR DESCRIPTION
This requires competitor code to explicitly use our API wrappers when they want time to advance. In turn this should make robot behaviour more predictable and allows us to simplify how we're running matches (as we no longer need to ensure they run at 1:1 real time).