### PR TITLE
Implement use_brake with torque/force control

### DIFF
--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -82,4 +82,4 @@ class MotorChannel:
     @use_brake.setter
     def use_brake(self, value: bool):
         """Set whether to brake when motor speed is 0"""
-        self.sr_motor.set_brake(value)
+        self.sr_motor._set_brake(value)

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -75,11 +75,11 @@ class MotorChannel:
         self.sr_motor.set_speed(translate(value, self.sr_motor))
 
     @property
-    def use_brake(self):
+    def use_brake(self) -> bool:
         """Whether to brake when motor speed is 0"""
         return self.sr_motor._use_brake
 
     @use_brake.setter
-    def use_brake(self, value):
+    def use_brake(self, value: bool):
         """Set whether to brake when motor speed is 0"""
         self.sr_motor.set_brake(value)

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -80,6 +80,6 @@ class MotorChannel:
         return self.sr_motor._use_brake
 
     @use_brake.setter
-    def use_brake(self, value: bool):
+    def use_brake(self, value: bool) -> None:
         """Set whether to brake when motor speed is 0"""
         self.sr_motor._set_brake(value)

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -50,8 +50,6 @@ class MotorChannel:
 
     def __init__(self, channel: int, sr_motor: Union[Gripper, Wheel, LinearMotor]) -> None:
         self.channel = channel
-        # Private shadow of use_brake
-        # self._use_brake = True # TODO create new thread for non-braking slowdown
 
         # There is currently no method for reading the power from a motor board
         self._power = 0
@@ -76,15 +74,12 @@ class MotorChannel:
 
         self.sr_motor.set_speed(translate(value, self.sr_motor))
 
-    ''''@property
-    def use_brake(self) -> bool:
-        "Whether to use the brake when at 0 speed"
-        return self._use_brake
+    @property
+    def use_brake(self):
+        """Whether to brake when motor speed is 0"""
+        return self.sr_motor._use_brake
 
     @use_brake.setter
-    def use_brake(self, value: bool) -> None:
-        self._use_brake = value
-
-        if self.power == 0:
-            "Implement the new braking setting"
-            self.power = 0'''
+    def use_brake(self, value):
+        """Set whether to brake when motor speed is 0"""
+        self.sr_motor.set_brake(value)

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -13,6 +13,12 @@ class MotorBase:
         self.webot_motor = webot.getMotor(motor_name)
         self.max_speed = self.webot_motor.getMaxVelocity()
 
+        # Apply the brake when this motor speed = 0 by default
+        self._use_brake = True
+
+    def set_brake(self, value: bool) -> None:
+        self._use_brake = value
+
 
 class Wheel(MotorBase):
     """
@@ -23,9 +29,17 @@ class Wheel(MotorBase):
         super().__init__(webot, motor_name)
         self.webot_motor.setPosition(float('inf'))
         self.webot_motor.setVelocity(0)
+        self.max_torque = self.webot_motor.getMaxTorque()
 
     def set_speed(self, speed: float) -> None:
         self.webot_motor.setVelocity(speed)
+
+        # If not using braking, set torque to 0.1 when motor speed is 0
+        # Otherwise set max torque
+        if(speed == 0 and not self._use_brake):
+            self.webot_motor.setAvailableTorque(0.1)
+        else:
+            self.webot_motor.setAvailableTorque(self.max_torque)
 
 
 class LinearMotor(MotorBase):
@@ -37,6 +51,7 @@ class LinearMotor(MotorBase):
         super().__init__(webot, motor_name)
         self.webot_motor.setPosition(0)
         self.webot_motor.setVelocity(0)
+        self.max_force = self.webot_motor.getMaxForce()
 
     def set_speed(self, speed: float) -> None:
         motor = self.webot_motor
@@ -45,6 +60,13 @@ class LinearMotor(MotorBase):
         else:
             motor.setPosition(motor.getMaxPosition())
         motor.setVelocity(abs(speed))
+
+        # If not using braking, set force to 0.1 when motor speed is 0
+        # Otherwise set max force
+        if(speed == 0 and not self._use_brake):
+            self.webot_motor.setAvailableForce(0.1)
+        else:
+            self.webot_motor.setAvailableForce(self.max_force)
 
 
 class Gripper(MotorBase):

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -7,6 +7,8 @@ class MotorBase:
     """
     A base class for any type of motor as these are common attributes
     """
+    # Rolling friction torque/force when braking disabled
+    ROLLING_FRICTION = 0.5 # Nm for rotary motors and N for linear motors
 
     def __init__(self, webot: Robot, motor_name: str) -> None:
         self.motor_name = motor_name
@@ -37,7 +39,7 @@ class Wheel(MotorBase):
         # If not using braking, set torque to 0.1 when motor speed is 0
         # Otherwise set max torque
         if speed == 0 and not self._use_brake:
-            self.webot_motor.setAvailableTorque(0.1)
+            self.webot_motor.setAvailableTorque(self.ROLLING_FRICTION)
         else:
             self.webot_motor.setAvailableTorque(self.max_torque)
 
@@ -64,7 +66,7 @@ class LinearMotor(MotorBase):
         # If not using braking, set force to 0.1 when motor speed is 0
         # Otherwise set max force
         if speed == 0 and not self._use_brake:
-            self.webot_motor.setAvailableForce(0.1)
+            self.webot_motor.setAvailableForce(self.ROLLING_FRICTION)
         else:
             self.webot_motor.setAvailableForce(self.max_force)
 

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -16,7 +16,7 @@ class MotorBase:
         # Apply the brake when this motor speed = 0 by default
         self._use_brake = True
 
-    def set_brake(self, value: bool) -> None:
+    def _set_brake(self, value: bool) -> None:
         self._use_brake = value
 
 
@@ -36,7 +36,7 @@ class Wheel(MotorBase):
 
         # If not using braking, set torque to 0.1 when motor speed is 0
         # Otherwise set max torque
-        if(speed == 0 and not self._use_brake):
+        if speed == 0 and not self._use_brake:
             self.webot_motor.setAvailableTorque(0.1)
         else:
             self.webot_motor.setAvailableTorque(self.max_torque)
@@ -63,7 +63,7 @@ class LinearMotor(MotorBase):
 
         # If not using braking, set force to 0.1 when motor speed is 0
         # Otherwise set max force
-        if(speed == 0 and not self._use_brake):
+        if speed == 0 and not self._use_brake:
             self.webot_motor.setAvailableForce(0.1)
         else:
             self.webot_motor.setAvailableForce(self.max_force)

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -8,7 +8,8 @@ class MotorBase:
     A base class for any type of motor as these are common attributes
     """
     # Rolling friction torque/force when braking disabled
-    ROLLING_FRICTION = 0.5 # Nm for rotary motors and N for linear motors
+    # (Nm for rotary motors and N for linear motors)
+    ROLLING_FRICTION = 0.5
 
     def __init__(self, webot: Robot, motor_name: str) -> None:
         self.motor_name = motor_name


### PR DESCRIPTION
This MR implements the SR command `use_brake` to specify whether a motor should stop hard or coast when velocity is set to 0. It is implemented by modifying the available torque/force for rotary and linear motors respectively. The available force when coasting is set to 0.1 to provide some friction to have a nice rolling stop, but this value can be tuned in the future. It is a trade off between coasting nicely but often spinning vs staying under control but not coasting very far.