### PR TITLE
convert station_codes to utf-8 in the API

### DIFF
--- a/modules/sr/robot/radio.py
+++ b/modules/sr/robot/radio.py
@@ -22,6 +22,7 @@ class TargetInfo(NamedTuple):
 def parse_radio_message(message: bytes, zone: int) -> Optional[TargetInfo]:
     try:
         station_code, owned_by = struct.unpack("!2sb", message)
+        station_code = station_code.decode('utf-8')
         owned_by = owned_by if owned_by is not UNCLAIMED else None
         return TargetInfo(station_code=station_code, owned_by=owned_by)
     except ValueError:


### PR DESCRIPTION
Logs before
`[<Target: info=TargetInfo(station_code=b'YL', owned_by=None), bearing=2.7078272999970876, strength=1.6794070930984721>]`
Logs after:
`[<Target: info=TargetInfo(station_code='YL', owned_by=None), bearing=2.7078272999970876, strength=1.6794070930984721>]`

(no `b` before code)