### PR TITLE
Add a few scientific libraries

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -1,4 +1,3 @@
-import re
 import sys
 import time
 import datetime
@@ -72,10 +71,9 @@ def check_required_libraries(path: Path) -> None:
     missing, incorrect = [], []
 
     for package in path.read_text().splitlines():
-        package_match = re.match(r"[\w|-]+==[\d|.]+", package)
-        if not package_match:
+        package = package.partition('#')[0].strip()
+        if not package:
             continue
-        package = package_match.group(0)
 
         try:
             pkg_resources.get_distribution(package)

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import time
 import datetime
@@ -71,9 +72,10 @@ def check_required_libraries(path: Path) -> None:
     missing, incorrect = [], []
 
     for package in path.read_text().splitlines():
-        package = package.partition('#')[0].strip()
-        if not package:
+        package_match = re.match(r"[\w|-]+==[\d|.]+", package)
+        if not package_match:
             continue
+        package = package_match.group(0)
 
         try:
             pkg_resources.get_distribution(package)

--- a/libraries.txt
+++ b/libraries.txt
@@ -11,10 +11,5 @@
 matplotlib==3.3.3
 numpy==1.19.3
 pandas==1.1.4
-torch==1.7.0 ; sys_platform != "win32"
 scikit-learn==0.23.2
 scipy==1.5.4
-
-
--f https://download.pytorch.org/whl/torch_stable.html
-torch==1.7.0+cpu ; sys_platform == "win32"

--- a/libraries.txt
+++ b/libraries.txt
@@ -8,4 +8,12 @@
 # matches, so we *don't* have the full range of requirements.txt supported
 # syntax available.
 
-matplotlib==3.2.2
+matplotlib==3.3.3
+numpy==1.19.3
+pandas==1.1.4
+torch==1.7.0 ; sys_platform != "win32"
+scipy==1.5.4
+
+
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.7.0+cpu ; sys_platform == "win32"

--- a/libraries.txt
+++ b/libraries.txt
@@ -12,6 +12,7 @@ matplotlib==3.3.3
 numpy==1.19.3
 pandas==1.1.4
 torch==1.7.0 ; sys_platform != "win32"
+scikit-learn==0.23.2
 scipy==1.5.4
 
 


### PR DESCRIPTION
As discussed in the latest competition meeting we want to add these libraries for teams to use.

I had to change our requirement checking logic to use regex to identify packages instead of partitioning strings due to the extra pip functionality required by pytorch in `libraries.txt`. I've attempted to make [the regex](regexr.com/5hk94) suitably generic so that the `get_distribution` call will work across operating systems (specifically `+cpu` wont be there on no win32 platforms). Its almost certainly not perfect but should work for the packages we currently depend on.