### PR TITLE
Simulator tweaks - Video improvements

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -145,7 +145,7 @@ def run_match(supervisor: Supervisor) -> None:
         robot.getField('customData').setSFString('start')
 
     # ... then un-pause the simulation, so they all start together
-    supervisor.simulationSetMode(Supervisor.SIMULATION_MODE_REAL_TIME)
+    supervisor.simulationSetMode(Supervisor.SIMULATION_MODE_RUN)
 
     time_step = int(supervisor.getBasicTimeStep())
     duration_ms = time_step * int(1000 * GAME_DURATION_SECONDS // time_step)

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -1,7 +1,7 @@
 #VRML_SIM R2020b utf8
 WorldInfo {
   coordinateSystem "NUE"
-  basicTimeStep 16
+  basicTimeStep 8
 }
 Viewpoint {
   orientation -0.9999095454609961 -0.012169594624247947 0.0057272910407683165 0.8997040656177113


### PR DESCRIPTION
Reduces the timestep to 8 since this appears to have no detriment to performance and changes the movie frame rate to 25 from 31.25.
Also sets comp mode simulation mode to run since we no longer need to run at real-time speed so we can save some time running matches.