### PR TITLE
Fix depreciation warnings in webots 2021a

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -57,10 +57,10 @@ class TerritoryController:
         return self._station_statuses[station_code]
 
     def setup(self) -> None:
-        self._emitters = {station_code: self._robot.getEmitter(station_code + "Emitter")
+        self._emitters = {station_code: self._robot.getDevice(station_code + "Emitter")
                           for station_code in StationCode}
 
-        self._receivers = {station_code: self._robot.getReceiver(station_code + "Receiver")
+        self._receivers = {station_code: self._robot.getDevice(station_code + "Receiver")
                            for station_code in StationCode}
         territory_controller.enable_receivers()
 

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -10,7 +10,7 @@ class MotorBase:
 
     def __init__(self, webot: Robot, motor_name: str) -> None:
         self.motor_name = motor_name
-        self.webot_motor = webot.getMotor(motor_name)
+        self.webot_motor = webot.getDevice(motor_name)
         self.max_speed = self.webot_motor.getMaxVelocity()
 
 

--- a/modules/sr/robot/radio.py
+++ b/modules/sr/robot/radio.py
@@ -92,9 +92,9 @@ class Radio:
 
     def __init__(self, webot: Robot, zone: int, step_lock: Lock) -> None:
         self._webot = webot
-        self._receiver = webot.getReceiver("robot receiver")
+        self._receiver = webot.getDevice("robot receiver")
         self._receiver.enable(1)
-        self._emitter = webot.getEmitter("robot emitter")
+        self._emitter = webot.getDevice("robot emitter")
         self._zone = zone
         self._step_lock = step_lock
 

--- a/modules/sr/robot/ruggeduino_devices.py
+++ b/modules/sr/robot/ruggeduino_devices.py
@@ -17,7 +17,7 @@ class DistanceSensor:
     UPPER_BOUND = 2
 
     def __init__(self, webot: Robot, sensor_name: str) -> None:
-        self.webot_sensor = webot.getDistanceSensor(sensor_name)
+        self.webot_sensor = webot.getDevice(sensor_name)
         self.webot_sensor.enable(int(webot.getBasicTimeStep()))
 
     def __get_scaled_distance(self) -> float:
@@ -46,7 +46,7 @@ class Microswitch:
     """
 
     def __init__(self, webot: Robot, sensor_name: str) -> None:
-        self.webot_sensor = webot.getTouchSensor(sensor_name)
+        self.webot_sensor = webot.getDevice(sensor_name)
         self.webot_sensor.enable(int(webot.getBasicTimeStep()))
 
     def read_value(self) -> bool:
@@ -69,7 +69,7 @@ class Led:
         limiter: OutputFrequencyLimiter,
     ) -> None:
         self._name = device_name
-        self.webot_sensor = webot.getLED(device_name)
+        self.webot_sensor = webot.getDevice(device_name)
         self._limiter = limiter
 
     def write_value(self, value: bool) -> None:


### PR DESCRIPTION
This pull request currently only replaces the depreciated `getX` methods with the `getDevice` method.
While this works in webots 2021a the `getDevice` method is [broken in 2020b](https://github.com/cyberbotics/webots/issues/2338) so fallbacks will be needed.
Additionally the stubs and types need to be added.

TLDR before merging:
- [ ] Add method stub for `Robot.getDevice`
- [ ] Add fallbacks to use previous methods for webots-202b compatibility
- [ ] Satisfy the typechecking for `getDevice` in all it's uses