### PR TITLE
Extract tee_streams for re-use

### DIFF
--- a/controllers/sr_controller/sr_controller.py
+++ b/controllers/sr_controller/sr_controller.py
@@ -126,37 +126,15 @@ def log_filename(zone_id: int) -> str:
     )
 
 
-def tee_streams(name: Path, zone_id: int) -> None:
-    """
-    Tee stdout and stderr also to the named log file.
-
-    Note: we intentionally don't provide a way to clean up the stream
-    replacement so that any error handling from Python which causes us to exit
-    is also captured by the log file.
-    """
-
-    log_file = name.open(mode='w')
-
-    prefix = '{}| '.format(zone_id)
-
-    sys.stdout = controller_utils.SimpleTee(  # type: ignore[assignment]
-        sys.stdout,
-        log_file,
-        prefix=prefix,
-    )
-    sys.stderr = controller_utils.SimpleTee(  # type: ignore[assignment]
-        sys.stderr,
-        log_file,
-        prefix=prefix,
-    )
-
-
 def main() -> None:
     robot_mode = controller_utils.get_robot_mode()
     robot_zone = get_robot_zone()
     robot_file = get_robot_file(robot_zone, robot_mode).resolve()
 
-    tee_streams(robot_file.parent / log_filename(robot_zone), robot_zone)
+    controller_utils.tee_streams(
+        robot_file.parent / log_filename(robot_zone),
+        prefix=f'{robot_zone}| ',
+    )
 
     if robot_zone == 0:
         # Only print once, but rely on Zone 0 always being run to ensure this is

--- a/modules/controller_utils/__init__.py
+++ b/modules/controller_utils/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime
 from typing import IO, Optional
 from pathlib import Path
@@ -94,3 +95,26 @@ class SimpleTee:
     def flush(self) -> None:
         for stream in self.streams:
             stream.flush()
+
+
+def tee_streams(name: Path, prefix: str = '') -> None:
+    """
+    Tee stdout and stderr also to the named log file.
+
+    Note: we intentionally don't provide a way to clean up the stream
+    replacement so that any error handling from Python which causes us to exit
+    is also captured by the log file.
+    """
+
+    log_file = name.open(mode='w')
+
+    sys.stdout = SimpleTee(  # type: ignore[assignment]
+        sys.stdout,
+        log_file,
+        prefix=prefix,
+    )
+    sys.stderr = SimpleTee(  # type: ignore[assignment]
+        sys.stderr,
+        log_file,
+        prefix=prefix,
+    )

--- a/modules/controller_utils/tests.py
+++ b/modules/controller_utils/tests.py
@@ -1,7 +1,12 @@
 import io
+import sys
+import tempfile
 import unittest
+import contextlib
+from pathlib import Path
+from unittest import mock
 
-from . import SimpleTee
+from . import SimpleTee, tee_streams
 
 
 class TestSimpleTee(unittest.TestCase):
@@ -69,3 +74,37 @@ class TestSimpleTee(unittest.TestCase):
             out.getvalue(),
             "Stream has wrong content after adding content containing newlines",
         )
+
+    def test_tee_streams(self) -> None:
+        # 'tee_streams' is designed to be used as part of one-shot processes, so
+        # it does some otherwise slightly unusual things. As a result we need to
+        # also do some slightly odd things to test it.
+        with tempfile.NamedTemporaryFile(mode='w+t') as f:
+            with contextlib.redirect_stdout(io.StringIO()) as new_stdout:
+                with contextlib.redirect_stderr(io.StringIO()) as new_stderr:
+                    # Fake the opening of the log file to avoid a leaked file
+                    # reference (and associated warning).
+                    with mock.patch('pathlib.Path.open', return_value=f):
+                        tee_streams(Path(f.name), prefix='prefix:')
+
+                    print('To Stdout')  # noqa:T001
+                    print('To Stderr', file=sys.stderr)  # noqa:T001
+
+            self.assertEqual(
+                'prefix:To Stdout\n',
+                new_stdout.getvalue(),
+                "Should have still sent the output to the 'real' stdout",
+            )
+
+            self.assertEqual(
+                'prefix:To Stderr\n',
+                new_stderr.getvalue(),
+                "Should have still sent the output to the 'real' stderr",
+            )
+
+            f.seek(0)
+            self.assertEqual(
+                'prefix:To Stdout\nprefix:To Stderr\n',
+                f.read(),
+                "Should have sent all to the log file",
+            )


### PR DESCRIPTION
I keep thinking I'm going to want to re-use this somewhere but ending up feeling it's a faff to do so and finding alternatives.
Even if this doesn't end up getting re-used, having it somewhere central feels better especially as this also adds some basic test coverage.