### PR TITLE
Push determination of the full recording path into a util

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -18,14 +18,14 @@ import controller_utils  # isort:skip
 GAME_DURATION_SECONDS = 120
 
 
-def get_recording_path() -> Path:
+def get_recording_stem() -> Path:
     now = datetime.datetime.now()
 
     date = now.date().isoformat()
 
     name: str = controller_utils.get_filename_safe_identifier()
 
-    return Path(date) / name
+    return REPO_ROOT / 'recordings' / date / name
 
 
 @contextlib.contextmanager
@@ -170,10 +170,10 @@ def main() -> None:
 
     remove_unused_robots(supervisor)
 
-    recording_path = REPO_ROOT / 'recordings' / get_recording_path()
+    recording_stem = get_recording_stem()
 
-    with record_animation(supervisor, recording_path.with_suffix('.html')):
-        with record_video(supervisor, recording_path.with_suffix('.mp4')):
+    with record_animation(supervisor, recording_stem.with_suffix('.html')):
+        with record_video(supervisor, recording_stem.with_suffix('.mp4')):
             run_match(supervisor)
 
 


### PR DESCRIPTION
This is extracted from my `match-automation` branch, which no longer looks like the direction we're going, as this part seems likely to still be useful. I'm not sure where we actually want the recordings to end up, however this will slightly simplify moving them when we get to that.