### PR TITLE
Make it possible to import SimulationMode for type checking

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -2,13 +2,16 @@ import sys
 import time
 import datetime
 import contextlib
-from typing import List, Tuple, Iterator
+from typing import List, Tuple, Iterator, TYPE_CHECKING
 from pathlib import Path
 
 import pkg_resources
 
 # Webots specific library
 from controller import Node, Supervisor  # isort:skip
+
+if TYPE_CHECKING:
+    from controller import SimulationMode
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -135,7 +138,7 @@ def remove_unused_robots(supervisor: Supervisor) -> None:
         robot.remove()
 
 
-def get_simulation_run_mode(supervisor: Supervisor):
+def get_simulation_run_mode(supervisor: Supervisor) -> 'SimulationMode':
     if supervisor.getDevice("2021a-compatibility") is None:
         # we are running version 2020b so the old command is used
         return Supervisor.SIMULATION_MODE_RUN

--- a/stubs/controller.py
+++ b/stubs/controller.py
@@ -1,5 +1,4 @@
-import enum
-from typing import List, Tuple, Optional, Sequence
+from typing import List, Tuple, NewType, Optional, Sequence
 
 
 class Device:
@@ -225,20 +224,16 @@ class Robot:
     def getDevice(self, name: str) -> Optional[Device]: ...
 
 
-class _SimulationMode(enum.Enum):
-    # These are probably `int` really, though as the values should be treated
-    # only as opaque identifiers that doesn't matter.
-    PAUSE = 'pause'
-    REAL_TIME = 'real_time'
-    RUN = 'run'
-    FAST = 'fast'
+# Beware: this type doesn't actually exist in Webots. It's just here for type
+# safety.
+SimulationMode = NewType('SimulationMode', int)
 
 
 class Supervisor(Robot):
-    SIMULATION_MODE_PAUSE = _SimulationMode.PAUSE
-    SIMULATION_MODE_REAL_TIME = _SimulationMode.REAL_TIME
-    SIMULATION_MODE_RUN = _SimulationMode.RUN
-    SIMULATION_MODE_FAST = _SimulationMode.FAST
+    SIMULATION_MODE_PAUSE: SimulationMode
+    SIMULATION_MODE_REAL_TIME: SimulationMode
+    SIMULATION_MODE_RUN: SimulationMode
+    SIMULATION_MODE_FAST: SimulationMode
 
     def getRoot(self) -> Node: ...
     def getSelf(self) -> Node: ...
@@ -265,8 +260,8 @@ class Supervisor(Robot):
 
     def simulationQuit(self, status: int) -> None: ...
     def simulationReset(self) -> None: ...
-    def simulationGetMode(self) -> _SimulationMode: ...
-    def simulationSetMode(self, mode: _SimulationMode) -> None: ...
+    def simulationGetMode(self) -> SimulationMode: ...
+    def simulationSetMode(self, mode: SimulationMode) -> None: ...
 
     def worldLoad(self, file: str) -> None: ...
     def worldSave(self, file: Optional[str] = None) -> bool: ...


### PR DESCRIPTION
This still needs to be guarded by `TYPE_CHECKING` as it's not really something which exists in Webots, however it is useful to be able to have this for use in used-defined signatures.