### PR TITLE
Reduce logging IO

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -58,8 +58,8 @@ class ClaimLog:
         }
 
         self._log: List[Tuple[StationCode, Claimant, float]] = []
-        # use < 0 so that the log format is written at least once
-        self._saved_log_length: int = -1
+        # starting with a dirty log ensure the structure is written for every match
+        self._log_is_dirty = True
 
     def get_claimant(self, station_code: StationCode) -> Claimant:
         return self._station_statuses[station_code]
@@ -71,6 +71,7 @@ class ClaimLog:
         claim_time: float,
     ) -> None:
         self._log.append((station_code, claimed_by, claim_time))
+        self._log_is_dirty = True
         print(f"{station_code} CLAIMED BY {claimed_by} AT {claim_time}s")  # noqa:T001
         self._station_statuses[station_code] = claimed_by
 
@@ -78,7 +79,7 @@ class ClaimLog:
         if not self._record_arena_actions:
             return
 
-        if self._saved_log_length == len(self._log):
+        if self._log_is_dirty is True:
             # don't write the log if nothing new has happened
             return
 
@@ -91,7 +92,7 @@ class ClaimLog:
             for station_code, claimed_by, claim_time in self._log
         ]})
 
-        self._saved_log_length = len(self._log)
+        self._log_is_dirty = False
 
 
 class TerritoryController:

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -58,7 +58,7 @@ class ClaimLog:
         }
 
         self._log: List[Tuple[StationCode, Claimant, float]] = []
-        # starting with a dirty log ensures the structure is written for every match
+        # Starting with a dirty log ensures the structure is written for every match.
         self._log_is_dirty = True
 
     def get_claimant(self, station_code: StationCode) -> Claimant:
@@ -80,7 +80,7 @@ class ClaimLog:
             return
 
         if not self._log_is_dirty:
-            # don't write the log if nothing new has happened
+            # Don't write the log if nothing new has happened.
             return
 
         controller_utils.record_arena_data({'territory_claims': [

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -79,7 +79,7 @@ class ClaimLog:
         if not self._record_arena_actions:
             return
 
-        if self._log_is_dirty:
+        if not self._log_is_dirty:
             # don't write the log if nothing new has happened
             return
 

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -58,6 +58,8 @@ class ClaimLog:
         }
 
         self._log: List[Tuple[StationCode, Claimant, float]] = []
+        # use < 0 so that the log format is written at least once
+        self._saved_log_length: int = -1
 
     def get_claimant(self, station_code: StationCode) -> Claimant:
         return self._station_statuses[station_code]
@@ -76,6 +78,10 @@ class ClaimLog:
         if not self._record_arena_actions:
             return
 
+        if self._saved_log_length == len(self._log):
+            # don't write the log if nothing new has happened
+            return
+
         controller_utils.record_arena_data({'territory_claims': [
             {
                 'zone': claimed_by.value,
@@ -84,6 +90,8 @@ class ClaimLog:
             }
             for station_code, claimed_by, claim_time in self._log
         ]})
+
+        self._saved_log_length = len(self._log)
 
 
 class TerritoryController:

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -58,7 +58,7 @@ class ClaimLog:
         }
 
         self._log: List[Tuple[StationCode, Claimant, float]] = []
-        # starting with a dirty log ensure the structure is written for every match
+        # starting with a dirty log ensures the structure is written for every match
         self._log_is_dirty = True
 
     def get_claimant(self, station_code: StationCode) -> Claimant:

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -79,7 +79,7 @@ class ClaimLog:
         if not self._record_arena_actions:
             return
 
-        if self._log_is_dirty is True:
+        if self._log_is_dirty:
             # don't write the log if nothing new has happened
             return
 


### PR DESCRIPTION
The match data does not need to be written to disk every timestep.
This branch now only writes the claim log after a change has occurred.

Writing the claim log to disk every timestep is 15,000 writes in a two-minute match.
By only writing after a territory claim has occurred this will be reduced to a handful of writes in most cases.

On my setup, this reduced the time to run a two-minute match by ~25% (bringing it inline with a match run on master) since the file was stored on a HDD.