### PR TITLE
Allow infinite LED changes within the same timestep

### DIFF
--- a/modules/sr/robot/output_frequency_limiter.py
+++ b/modules/sr/robot/output_frequency_limiter.py
@@ -15,7 +15,9 @@ class OutputFrequencyLimiter:
         now = self._webot.getTime()
         diff = now - self._last_change
 
-        # allow infinite changes within a timestep
+        # Changes within a timestep always all happen during the same
+        # render cycle and therefore cannot contribute to additional strobing.
+        # It's therefore safe to allow several changes within the same timestep.
         if diff == 0:
             return True
 

--- a/modules/sr/robot/output_frequency_limiter.py
+++ b/modules/sr/robot/output_frequency_limiter.py
@@ -14,6 +14,11 @@ class OutputFrequencyLimiter:
     def can_change(self) -> bool:
         now = self._webot.getTime()
         diff = now - self._last_change
+        print(diff)
+
+        # allow infinite changes within a timestep
+        if diff == 0:
+            return True
 
         if diff < MIN_TIME_BETWEEN_CHANGES:
             return False

--- a/modules/sr/robot/output_frequency_limiter.py
+++ b/modules/sr/robot/output_frequency_limiter.py
@@ -14,7 +14,6 @@ class OutputFrequencyLimiter:
     def can_change(self) -> bool:
         now = self._webot.getTime()
         diff = now - self._last_change
-        print(diff)
 
         # allow infinite changes within a timestep
         if diff == 0:

--- a/modules/sr/robot/output_frequency_limiter.py
+++ b/modules/sr/robot/output_frequency_limiter.py
@@ -15,7 +15,7 @@ class OutputFrequencyLimiter:
         now = self._webot.getTime()
         diff = now - self._last_change
 
-        # Changes within a timestep always all happen during the same
+        # Changes within a timestep will happen during the same
         # render cycle and therefore cannot contribute to additional strobing.
         # It's therefore safe to allow several changes within the same timestep.
         if diff == 0:


### PR DESCRIPTION
Since all changes within a timestep visually apply together changing multiple LEDs within a single timestep is not an epilepsy issue so we should be limiting it.

This also has the side effect of allowing LEDs to be set at the start of the match (although not during the first half second as webots time starts at 0).