### PR TITLE
Change rate limiter text to refer to led pin

### DIFF
--- a/modules/sr/robot/ruggeduino.py
+++ b/modules/sr/robot/ruggeduino.py
@@ -35,12 +35,7 @@ def init_ruggeduino_array(webot: Robot) -> 'List[Ruggeduino]':
 
     limiter = OutputFrequencyLimiter(webot)
     digital_output_array = [
-        Led(
-            webot,
-            name,
-            limiter,
-            pin,
-        )
+        Led(webot, name, limiter, pin)
         for pin, name in enumerate(
             led_names,
             start=Ruggeduino.DIGITAL_PIN_START + len(digital_input_array),

--- a/modules/sr/robot/ruggeduino.py
+++ b/modules/sr/robot/ruggeduino.py
@@ -39,9 +39,12 @@ def init_ruggeduino_array(webot: Robot) -> 'List[Ruggeduino]':
             webot,
             name,
             limiter,
-            index + Ruggeduino.DIGITAL_PIN_START + len(digital_input_array),
+            pin,
         )
-        for index, name in enumerate(led_names)
+        for pin, name in enumerate(
+            led_names,
+            start=Ruggeduino.DIGITAL_PIN_START + len(digital_input_array),
+        )
     ]
 
     return [Ruggeduino(analogue_input_array, digital_input_array, digital_output_array)]

--- a/modules/sr/robot/ruggeduino.py
+++ b/modules/sr/robot/ruggeduino.py
@@ -34,7 +34,15 @@ def init_ruggeduino_array(webot: Robot) -> 'List[Ruggeduino]':
     digital_input_array = [Microswitch(webot, name) for name in switch_names]
 
     limiter = OutputFrequencyLimiter(webot)
-    digital_output_array = [Led(webot, name, limiter) for name in led_names]
+    digital_output_array = [
+        Led(
+            webot,
+            name,
+            limiter,
+            index + Ruggeduino.DIGITAL_PIN_START + len(digital_input_array),
+        )
+        for index, name in enumerate(led_names)
+    ]
 
     return [Ruggeduino(analogue_input_array, digital_input_array, digital_output_array)]
 

--- a/modules/sr/robot/ruggeduino_devices.py
+++ b/modules/sr/robot/ruggeduino_devices.py
@@ -74,7 +74,6 @@ class Led:
         limiter: OutputFrequencyLimiter,
         pin_num: int,
     ) -> None:
-        self._name = device_name
         self.webot_sensor = get_robot_device(webot, device_name, LED)
         self._limiter = limiter
         self._pin_num = pin_num

--- a/modules/sr/robot/ruggeduino_devices.py
+++ b/modules/sr/robot/ruggeduino_devices.py
@@ -72,16 +72,18 @@ class Led:
         webot: Robot,
         device_name: str,
         limiter: OutputFrequencyLimiter,
+        pin_num: int,
     ) -> None:
         self._name = device_name
         self.webot_sensor = get_robot_device(webot, device_name, LED)
         self._limiter = limiter
+        self._pin_num = pin_num
 
     def write_value(self, value: bool) -> None:
         if not self._limiter.can_change():
             LOGGER.warning(
-                "Rate limited change to LED output (requested setting %s to %r)",
-                self._name,
+                "Rate limited change to LED output (requested setting LED on pin %d to %r)",
+                self._pin_num,
                 value,
             )
             return


### PR DESCRIPTION
Error messages are now in the form: `requested setting LED on pin X to False` instead of using their device names.