### PR TITLE
Allow ARENA_ROOT to be a path relative to REPO_ROOT

### DIFF
--- a/modules/controller_utils/__init__.py
+++ b/modules/controller_utils/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Root directory of the specification of the Arena (and match)
-ARENA_ROOT = Path(os.environ.get('ARENA_ROOT', REPO_ROOT.parent))
+ARENA_ROOT = (REPO_ROOT / os.environ.get('ARENA_ROOT', '..')).resolve()
 
 
 ROBOT_IDS_TO_CORNERS = {


### PR DESCRIPTION
In #261 we show setting `ARENA_ROOT` to a relative path, this currently does not work with the variable being taken relative to each file accessing it.

This changes the behaviour of the `ARENA_ROOT` environment variable to be either an absolute path or relative to `REPO_ROOT`.