### PR TITLE
Require ARENA_ROOT is absolute path

### DIFF
--- a/modules/controller_utils/__init__.py
+++ b/modules/controller_utils/__init__.py
@@ -11,6 +11,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 # Root directory of the specification of the Arena (and match)
 ARENA_ROOT = Path(os.environ.get('ARENA_ROOT', REPO_ROOT.parent))
 
+if not ARENA_ROOT.is_absolute():
+    # It turns out that Webots sets the current directory of each controller to
+    # the directory which contains the controller file. Since those are all
+    # different, relative paths aren't meaningful.
+    # Hint: `$PWD` or `%CD%` may be useful to construct an absolute path from
+    # your relative path.
+    raise ValueError(f"'ARENA_ROOT' must be an absolute path, got '{ARENA_ROOT}'")
+
 MODE_FILE = ARENA_ROOT / 'robot_mode.txt'
 MATCH_FILE = ARENA_ROOT / 'match.json'
 


### PR DESCRIPTION
This aims to resolve the concern raised at https://github.com/srobo/competition-simulator/pull/256#discussion_r549682332, in line with the conversation on #266.