### PR TITLE
Fix deadlock race in wait start

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -137,7 +137,7 @@ def get_robots(
 def wait_until_robots_ready(supervisor: Supervisor) -> None:
     time_step = int(supervisor.getBasicTimeStep())
 
-    for zone_id, robot in get_robots(supervisor):
+    for zone_id, robot in get_robots(supervisor, skip_missing=True):
         # Robot.wait_start sets this to 'ready', then waits to see 'start'
         field = robot.getField('customData')
 
@@ -147,11 +147,6 @@ def wait_until_robots_ready(supervisor: Supervisor) -> None:
                 supervisor.step(time_step)
 
         print("Zone {} ready".format(zone_id))
-
-
-def prepare(supervisor: Supervisor) -> None:
-    wait_until_robots_ready(supervisor)
-    supervisor.simulationSetMode(Supervisor.SIMULATION_MODE_PAUSE)
 
 
 def remove_unused_robots(supervisor: Supervisor) -> None:
@@ -217,13 +212,14 @@ def main() -> None:
     supervisor = Supervisor()
 
     with propagate_exit_code(supervisor):
-        prepare(supervisor)
+        remove_unused_robots(supervisor)
+        wait_until_robots_ready(supervisor)
+
+        supervisor.simulationSetMode(Supervisor.SIMULATION_MODE_PAUSE)
 
         # Check after we've paused the sim so that any errors won't be masked by
         # subsequent console output from a robot.
         check_required_libraries(REPO_ROOT / 'libraries.txt')
-
-        remove_unused_robots(supervisor)
 
         recording_stem = controller_utils.get_recording_stem()
 

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -143,7 +143,7 @@ def wait_until_robots_ready(supervisor: Supervisor) -> None:
 
         if field.getSFString() != 'ready':
             print("Waiting for {}".format(zone_id))
-            while field.getSFString():
+            while field.getSFString() != 'ready':
                 supervisor.step(time_step)
 
         print("Zone {} ready".format(zone_id))


### PR DESCRIPTION
This fixes a bug where the competition supervisor could end up setting the `start` flag before the robots were `ready`. When that happens, the robots end up over-writing the flag with their own `ready` flag, never seeing the `start` flag and thus getting stuck in a loop.

The first commit here does some re-ordering of the arena setup in order that we don't try to wait for robots which may not exist.