### PR TITLE
Use Claimant name in territory controller log messages

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -73,7 +73,7 @@ class ClaimLog:
     ) -> None:
         self._log.append((station_code, claimed_by, claim_time))
         self._log_is_dirty = True
-        print(f"{station_code} CLAIMED BY {claimed_by} AT {claim_time}s")  # noqa:T001
+        print(f"{station_code} CLAIMED BY {claimed_by.name} AT {claim_time}s")  # noqa:T001
         self._station_statuses[station_code] = claimed_by
 
     def record_captures(self) -> None:


### PR DESCRIPTION
This avoids territories becoming unclaimed printing `BE CLAIMED BY -1 AT 2s`.
An instead prints `BE CLAIMED BY UNCLAIMED AT 2s`.