### PR TITLE
Add script to zip logs in archive_dir

### DIFF
--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -9,7 +9,7 @@ import argparse
 import datetime
 from typing import List
 from pathlib import Path
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 
 
 def zip_folder(folder: Path, output_dir: Path, suffix: str, include_date: bool) -> str:
@@ -83,6 +83,17 @@ def parse_args() -> argparse.Namespace:
         action='store_true',
         dest='combined',
     )
+    parser.add_argument(
+        '--animations',
+        help=(
+            "Include the match animation files. "
+            "'all' creates a separate archive of all matches, "
+            "'separate' does the same as 'all' but excludes "
+            "the archive from the combined archive."
+        ),
+        choices=('all', 'separate'),
+        default=None,
+    )
     return parser.parse_args()
 
 
@@ -113,10 +124,32 @@ def main(args: argparse.Namespace) -> None:
             args.include_date,
         ))
 
+    if args.animations in ('all', 'separate'):
+        with ZipFile(
+            args.output_dir / f'animations{suffix_str}.zip',
+            'w',
+            compression=ZIP_DEFLATED,
+        ) as zipfile:
+            for rec_file in (args.archives_dir / 'recordings').iterdir():
+                if rec_file.suffix == '.mp4':
+                    continue
+                zipfile.write(rec_file.resolve(), rec_file.name)
+
+            # save animation textures
+            for texture in (args.archives_dir / 'recordings/textures').glob('**/*'):
+                zipfile.write(
+                    texture.resolve(),
+                    texture.relative_to(args.archives_dir / 'recordings'),
+                )
+
     if args.combined:
         with ZipFile(args.output_dir / f'combined{suffix_str}.zip', 'w') as zipfile:
             for logs_archive in logs_archives:
                 zipfile.write(args.output_dir / logs_archive, logs_archive)
+
+            if args.animations == 'all':
+                animation_zip = f'animations{suffix_str}.zip'
+                zipfile.write(args.output_dir / animation_zip, animation_zip)
 
 
 if __name__ == '__main__':

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -7,11 +7,13 @@ import re
 import shutil
 import argparse
 import datetime
-import tempfile
+import contextlib
+from typing import Union, Iterator
 from pathlib import Path
+from zipfile import ZipFile
 
 
-def zip_folder(folder: Path, args: argparse.Namespace) -> None:
+def zip_folder(folder: Path, args: argparse.Namespace) -> str:
     tla = folder.name
     zip_name = f'team-{tla}'
 
@@ -26,6 +28,7 @@ def zip_folder(folder: Path, args: argparse.Namespace) -> None:
         root_dir=folder,
         base_dir='.',
     )
+    return f'{zip_name}.zip'
 
 
 def is_team_logs_folder(folder: Path) -> bool:
@@ -41,6 +44,15 @@ def is_team_logs_folder(folder: Path) -> bool:
         return True
 
     return False
+
+
+@contextlib.contextmanager
+def optional_zip(filename: Path, create_archive: bool) -> Iterator[Union[None, ZipFile]]:
+    if create_archive:
+        with ZipFile(filename, 'w') as zipfile:
+            yield zipfile
+    else:
+        yield None
 
 
 def parse_args() -> argparse.Namespace:
@@ -81,8 +93,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         '--combined',
         help=(
-            "Create a combined archive which contains all the other log archives. "
-            "This is achieved by creating an archive of the contents of the output directory."
+            "Create a combined archive which contains all the other log archives."
         ),
         action='store_true',
     )
@@ -93,30 +104,20 @@ def main(args: argparse.Namespace) -> None:
     # make sure output directory exists
     args.output_dir.mkdir(exist_ok=True)
 
-    for folder in args.archives_dir.iterdir():
-        if not folder.is_dir():
-            # skip files in the archive directory
-            continue
+    with optional_zip(args.output_dir / 'combined2.zip', args.combined) as zipfile:
+        for folder in args.archives_dir.iterdir():
+            if not folder.is_dir():
+                # skip files in the archive directory
+                continue
 
-        if not is_team_logs_folder(folder):
-            # skip unrelated directories
-            continue
+            if not is_team_logs_folder(folder):
+                # skip unrelated directories
+                continue
 
-        zip_folder(folder, args)
+            logs_archive = zip_folder(folder, args)
 
-    if args.combined:
-        # a temporary directory is used since the zip file
-        # can't be created in the directory being archived
-        with tempfile.TemporaryDirectory() as tmpdir_name:
-            # create a combined archive
-            tmpdir_path = Path(tmpdir_name)
-            shutil.make_archive(
-                str(tmpdir_path / 'combined'),
-                'zip',
-                root_dir=args.output_dir,
-                base_dir='.',
-            )
-            shutil.copy(tmpdir_path / 'combined.zip', args.output_dir)
+            if args.combined and isinstance(zipfile, ZipFile):
+                zipfile.write(args.output_dir / logs_archive, logs_archive)
 
 
 if __name__ == '__main__':

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -40,10 +40,7 @@ def is_team_logs_folder(folder: Path) -> bool:
 
     # Using option 3
     # folder names are three uppercase letters and an optional number
-    if re.match(r'[A-Z]{3}[0-9]*$', folder.name):
-        return True
-
-    return False
+    return bool(re.search(r'^[A-Z]{3}[0-9]?$', folder.name))
 
 
 @contextlib.contextmanager

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -83,6 +83,7 @@ def parse_args() -> argparse.Namespace:
             "Create an additional combined archive which contains all the other log archives."
         ),
         action='store_true',
+        dest='combined',
     )
     return parser.parse_args()
 

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -7,8 +7,7 @@ import re
 import shutil
 import argparse
 import datetime
-import contextlib
-from typing import Iterator, Optional
+from typing import List
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -41,15 +40,6 @@ def is_team_logs_folder(folder: Path) -> bool:
     # Using option 3
     # folder names are three uppercase letters and an optional number
     return bool(re.search(r'^[A-Z]{3}[0-9]?$', folder.name))
-
-
-@contextlib.contextmanager
-def optional_zip(filename: Path, create_archive: bool) -> Iterator[Optional[ZipFile]]:
-    if create_archive:
-        with ZipFile(filename, 'w') as zipfile:
-            yield zipfile
-    else:
-        yield None
 
 
 def parse_args() -> argparse.Namespace:
@@ -101,19 +91,27 @@ def main(args: argparse.Namespace) -> None:
     # make sure output directory exists
     args.output_dir.mkdir(exist_ok=True)
 
-    with optional_zip(args.output_dir / 'combined.zip', args.combined) as zipfile:
-        for folder in args.archives_dir.iterdir():
-            if not folder.is_dir():
-                # skip files in the archive directory
-                continue
+    logs_archives: List[str] = []
 
-            if not is_team_logs_folder(folder):
-                # skip unrelated directories
-                continue
+    for folder in args.archives_dir.iterdir():
+        if not folder.is_dir():
+            # skip files in the archive directory
+            continue
 
-            logs_archive = zip_folder(folder, args.output_dir, args.suffix, args.include_date)
+        if not is_team_logs_folder(folder):
+            # skip unrelated directories
+            continue
 
-            if args.combined and isinstance(zipfile, ZipFile):
+        logs_archives.append(zip_folder(
+            folder,
+            args.output_dir,
+            args.suffix,
+            args.include_date,
+        ))
+
+    if args.combined:
+        with ZipFile(args.output_dir / 'combined.zip', 'w') as zipfile:
+            for logs_archive in logs_archives:
                 zipfile.write(args.output_dir / logs_archive, logs_archive)
 
 

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -104,7 +104,7 @@ def main(args: argparse.Namespace) -> None:
     # make sure output directory exists
     args.output_dir.mkdir(exist_ok=True)
 
-    with optional_zip(args.output_dir / 'combined2.zip', args.combined) as zipfile:
+    with optional_zip(args.output_dir / 'combined.zip', args.combined) as zipfile:
         for folder in args.archives_dir.iterdir():
             if not folder.is_dir():
                 # skip files in the archive directory

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+A script to zip the logs produced by a series of competition matches.
+"""
+
+import re
+import shutil
+import argparse
+import datetime
+import tempfile
+from pathlib import Path
+
+
+def zip_folder(folder: Path, args: argparse.Namespace) -> None:
+    tla = folder.name
+    zip_name = f'team-{tla}'
+
+    if args.suffix:
+        zip_name += f'-{args.suffix}'
+    if not args.no_date:
+        zip_name += f'-{datetime.date.today()}'
+
+    shutil.make_archive(
+        f'{args.output_dir / zip_name}',
+        'zip',
+        root_dir=folder,
+        base_dir='.',
+    )
+
+
+def is_team_logs_folder(folder: Path) -> bool:
+    # Options for detecting which folders are logs:
+    # 1. everthing except recordings, matches
+    # 2. folders w/ matching zip file names
+    # 3. regex of folder name
+    # 4. regex of folder contents names
+
+    # Using option 3
+    # folder names are three uppercase letters and an optional number
+    if re.match(r'[A-Z]{3}[0-9]*$', folder.name):
+        return True
+
+    return False
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'archives_dir',
+        help=(
+            "The directory containing folders of the teams' robot logs, "
+            "named for the teams' TLAs. This directory also contains the "
+            "teams' robot code, as Zip archives and the match recordings."
+        ),
+        type=Path,
+    )
+    parser.add_argument(
+        'output_dir',
+        help=(
+            "The directory to place the resulting log Zip archives. "
+            "This should be an empty directory."
+        ),
+        type=Path,
+    )
+    parser.add_argument(
+        '--suffix',
+        help=(
+            "Adds a suffix to the Zip archive name. "
+            "Archive names follow the format: team-<TLA>-<suffix>-<date>.zip"
+        ),
+        default="",
+    )
+    parser.add_argument(
+        '--no-date',
+        help=(
+            "Remove the date from the archive name."
+        ),
+        action='store_true',
+    )
+    parser.add_argument(
+        '--combined',
+        help=(
+            "Create a combined archive which contains all the other log archives. "
+            "This is achieved by creating an archive of the contents of the output directory."
+        ),
+        action='store_true',
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    # make sure output directory exists
+    args.output_dir.mkdir(exist_ok=True)
+
+    for folder in args.archives_dir.iterdir():
+        if not folder.is_dir():
+            # skip files in the archive directory
+            continue
+
+        if not is_team_logs_folder(folder):
+            # skip unrelated directories
+            continue
+
+        zip_folder(folder, args)
+
+    if args.combined:
+        # a temporary directory is used since the zip file
+        # can't be created in the directory being archived
+        with tempfile.TemporaryDirectory() as tmpdir_name:
+            # create a combined archive
+            tmpdir_path = Path(tmpdir_name)
+            shutil.make_archive(
+                str(tmpdir_path / 'combined'),
+                'zip',
+                root_dir=args.output_dir,
+                base_dir='.',
+            )
+            shutil.copy(tmpdir_path / 'combined.zip', args.output_dir)
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -17,7 +17,7 @@ def zip_folder(folder: Path, args: argparse.Namespace) -> None:
 
     if args.suffix:
         zip_name += f'-{args.suffix}'
-    if not args.no_date:
+    if args.include_date:
         zip_name += f'-{datetime.date.today()}'
 
     shutil.make_archive(
@@ -75,7 +75,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Remove the date from the archive name."
         ),
-        action='store_true',
+        dest='include_date',
+        action='store_false',
     )
     parser.add_argument(
         '--combined',

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -91,9 +91,9 @@ def parse_args() -> argparse.Namespace:
         action='store_false',
     )
     parser.add_argument(
-        '--combined',
+        '--with-combined',
         help=(
-            "Create a combined archive which contains all the other log archives."
+            "Create an additional combined archive which contains all the other log archives."
         ),
         action='store_true',
     )

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -14,10 +14,8 @@ from zipfile import ZipFile
 
 def zip_folder(folder: Path, output_dir: Path, suffix: str, include_date: bool) -> str:
     tla = folder.name
-    zip_name = f'team-{tla}'
+    zip_name = f'team-{tla}{suffix}'
 
-    if suffix:
-        zip_name += f'-{suffix}'
     if include_date:
         zip_name += f'-{datetime.date.today()}'
 
@@ -94,6 +92,11 @@ def main(args: argparse.Namespace) -> None:
 
     logs_archives: List[str] = []
 
+    if args.suffix:
+        suffix_str = f'-{args.suffix}'
+    else:
+        suffix_str = ""
+
     for folder in args.archives_dir.iterdir():
         if not folder.is_dir():
             # skip files in the archive directory
@@ -106,12 +109,12 @@ def main(args: argparse.Namespace) -> None:
         logs_archives.append(zip_folder(
             folder,
             args.output_dir,
-            args.suffix,
+            suffix_str,
             args.include_date,
         ))
 
     if args.combined:
-        with ZipFile(args.output_dir / 'combined.zip', 'w') as zipfile:
+        with ZipFile(args.output_dir / f'combined{suffix_str}.zip', 'w') as zipfile:
             for logs_archive in logs_archives:
                 zipfile.write(args.output_dir / logs_archive, logs_archive)
 

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -8,7 +8,7 @@ import shutil
 import argparse
 import datetime
 import contextlib
-from typing import Union, Iterator
+from typing import Iterator, Optional
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -47,7 +47,7 @@ def is_team_logs_folder(folder: Path) -> bool:
 
 
 @contextlib.contextmanager
-def optional_zip(filename: Path, create_archive: bool) -> Iterator[Union[None, ZipFile]]:
+def optional_zip(filename: Path, create_archive: bool) -> Iterator[Optional[ZipFile]]:
     if create_archive:
         with ZipFile(filename, 'w') as zipfile:
             yield zipfile

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -13,17 +13,17 @@ from pathlib import Path
 from zipfile import ZipFile
 
 
-def zip_folder(folder: Path, args: argparse.Namespace) -> str:
+def zip_folder(folder: Path, output_dir: Path, suffix: str, include_date: bool) -> str:
     tla = folder.name
     zip_name = f'team-{tla}'
 
-    if args.suffix:
-        zip_name += f'-{args.suffix}'
-    if args.include_date:
+    if suffix:
+        zip_name += f'-{suffix}'
+    if include_date:
         zip_name += f'-{datetime.date.today()}'
 
     shutil.make_archive(
-        f'{args.output_dir / zip_name}',
+        f'{output_dir / zip_name}',
         'zip',
         root_dir=folder,
         base_dir='.',
@@ -111,7 +111,7 @@ def main(args: argparse.Namespace) -> None:
                 # skip unrelated directories
                 continue
 
-            logs_archive = zip_folder(folder, args)
+            logs_archive = zip_folder(folder, args.output_dir, args.suffix, args.include_date)
 
             if args.combined and isinstance(zipfile, ZipFile):
                 zipfile.write(args.output_dir / logs_archive, logs_archive)

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -29,14 +29,7 @@ def zip_folder(folder: Path, output_dir: Path, suffix: str, include_date: bool) 
 
 
 def is_team_logs_folder(folder: Path) -> bool:
-    # Options for detecting which folders are logs:
-    # 1. everthing except recordings, matches
-    # 2. folders w/ matching zip file names
-    # 3. regex of folder name
-    # 4. regex of folder contents names
-
-    # Using option 3
-    # folder names are three uppercase letters and an optional number
+    # team folder names are three uppercase letters and an optional number
     return bool(re.search(r'^[A-Z]{3}[0-9]?$', folder.name))
 
 

--- a/script/zip-comp-logs
+++ b/script/zip-comp-logs
@@ -136,7 +136,7 @@ def main(args: argparse.Namespace) -> None:
                 zipfile.write(rec_file.resolve(), rec_file.name)
 
             # save animation textures
-            for texture in (args.archives_dir / 'recordings/textures').glob('**/*'):
+            for texture in (args.archives_dir / 'recordings' / 'textures').glob('**/*'):
                 zipfile.write(
                     texture.resolve(),
                     texture.relative_to(args.archives_dir / 'recordings'),


### PR DESCRIPTION
Using `./script/zip-comp-logs archives logs --combined` converts
```
archives
├── ABC
│   ├── log-zone-0-match-22.txt
│   ├── log-zone-0-match-23.txt
│   └── log-zone-1-match-24.txt
├── ABC.zip
├── DEF
│   ├── log-zone-1-match-22.txt
│   └── log-zone-1-match-23.txt
├── DEF.zip
├── matches
│   ├── 00x.yaml
│   ├── 022.yaml
│   ├── 023.yaml
│   └── 024.yaml
└── recordings
    ├── match-22.html
    ├── match-22.json
    ├── match-22.mp4
    ├── match-22.x3d
    ├── match-23.html
    ├── match-23.json
    ├── match-23.mp4
    ├── match-23.x3d
    ├── match-24.html
    ├── match-24.json
    ├── match-24.mp4
    ├── match-24.x3d
    └── textures
        └──...
```
to
```
logs
├── combined.zip
├── team-ABC-2021-01-22.zip
└── team-DEF-2021-01-22.zip
```

There are additional options to remove the date from the filename and add a suffix between the TLA and date sections.

The method for identifying which folders are the teams' logs isn't great and simply zips all folders whose name is 3 uppercase letters and an optional number.