### PR TITLE
Add flag to inhibit movie creation in comp mode

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 import contextlib
@@ -33,6 +34,11 @@ def record_video(supervisor: Supervisor, file_path: Path) -> Iterator[None]:
     print("Saving video to {}".format(file_path))
 
     config = controller_utils.get_recording_config()
+    if 'SR_COMP_NO_RECORD' in os.environ:
+        print('Not recording movie')
+        yield
+        return
+
     supervisor.movieStartRecording(
         str(file_path),
         width=config.resolution.width,

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import time
 import contextlib

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -30,13 +30,14 @@ def record_animation(supervisor: Supervisor, file_path: Path) -> Iterator[None]:
 @contextlib.contextmanager
 def record_video(supervisor: Supervisor, file_path: Path) -> Iterator[None]:
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    print("Saving video to {}".format(file_path))
 
     config = controller_utils.get_recording_config()
     if config.quality == 0:
         print('Not recording movie')
         yield
         return
+    else:
+        print("Saving video to {}".format(file_path))
 
     supervisor.movieStartRecording(
         str(file_path),

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -34,7 +34,7 @@ def record_video(supervisor: Supervisor, file_path: Path) -> Iterator[None]:
     print("Saving video to {}".format(file_path))
 
     config = controller_utils.get_recording_config()
-    if 'SR_COMP_NO_RECORD' in os.environ:
+    if config.quality == 0:
         print('Not recording movie')
         yield
         return


### PR DESCRIPTION
Since we are looking at testing code by running short matches in CI and the videos created are discarded, it is unnecessary to record the movie in the first place.

Not doing a recording greatly increases the speed of the simulation and as such decreases the CI time.

Fixes #290