### PR TITLE
Reflow wrapped lines for visual balance

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -147,7 +147,8 @@ class AttachedTerritories:
         self,
     ) -> Dict[Union[StationCode, TerritoryRoot], Set[StationCode]]:
         adjacent_zones: Dict[
-            Union[StationCode, TerritoryRoot], Set[StationCode],
+            Union[StationCode, TerritoryRoot],
+            Set[StationCode],
         ] = defaultdict(set)
 
         for link_codes in TERRITORY_LINKS:

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -412,8 +412,10 @@ class TerritoryController:
 
     def transmit_pulses(self) -> None:
         for station_code, emitter in self._emitters.items():
-            emitter.send(struct.pack("!2sb", station_code.encode('ASCII'),
-                         int(self._claim_log.get_claimant(station_code))))
+            emitter.send(
+                struct.pack("!2sb", station_code.encode('ASCII'),
+                int(self._claim_log.get_claimant(station_code))),
+            )
 
     def main(self) -> None:
         timestep = self._robot.getBasicTimeStep()

--- a/controllers/territory_controller/tests.py
+++ b/controllers/territory_controller/tests.py
@@ -18,8 +18,14 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 class TestAttachedTerritories(unittest.TestCase):
     'Test build_attached_capture_trees/get_attached_territories'
 
-    _zone_0_territories = {StationCode.BG, StationCode.TS, StationCode.OX,
-                           StationCode.VB, StationCode.BE, StationCode.SZ}
+    _zone_0_territories = {
+        StationCode.BG,
+        StationCode.TS,
+        StationCode.OX,
+        StationCode.VB,
+        StationCode.BE,
+        StationCode.SZ,
+    }
     _zone_1_territories = {StationCode.PN, StationCode.EY, StationCode.PO, StationCode.YL}
     _zone_1_disconnected = {StationCode.PN, StationCode.EY}
 
@@ -65,7 +71,9 @@ class TestAttachedTerritories(unittest.TestCase):
     def test_stations_can_capture(self) -> None:
         for station in {StationCode.PN, StationCode.EY, StationCode.SW, StationCode.PO}:
             capturable = self.attached_territories.can_capture_station(
-                station, Claimant.ZONE_0, self.connected_territories,
+                station,
+                Claimant.ZONE_0,
+                self.connected_territories,
             )
             self.assertEqual(
                 capturable,
@@ -75,7 +83,9 @@ class TestAttachedTerritories(unittest.TestCase):
 
         for station in {StationCode.BE, StationCode.SW, StationCode.HV}:
             capturable = self.attached_territories.can_capture_station(
-                station, Claimant.ZONE_1, self.connected_territories,
+                station,
+                Claimant.ZONE_1,
+                self.connected_territories,
             )
             self.assertEqual(
                 capturable,
@@ -86,7 +96,9 @@ class TestAttachedTerritories(unittest.TestCase):
     def test_stations_cant_capture(self) -> None:
         for station in {StationCode.YL, StationCode.BN, StationCode.HV}:
             capturable = self.attached_territories.can_capture_station(
-                station, Claimant.ZONE_0, self.connected_territories,
+                station,
+                Claimant.ZONE_0,
+                self.connected_territories,
             )
             self.assertEqual(
                 capturable,
@@ -94,10 +106,17 @@ class TestAttachedTerritories(unittest.TestCase):
                 f'Zone 0 should not be able to capture {station}',
             )
 
-        for station in {StationCode.PN, StationCode.EY, StationCode.SZ,
-                        StationCode.BN, StationCode.VB}:
+        for station in {
+            StationCode.PN,
+            StationCode.EY,
+            StationCode.SZ,
+            StationCode.BN,
+            StationCode.VB,
+        }:
             capturable = self.attached_territories.can_capture_station(
-                station, Claimant.ZONE_1, self.connected_territories,
+                station,
+                Claimant.ZONE_1,
+                self.connected_territories,
             )
             self.assertEqual(
                 capturable,


### PR DESCRIPTION
This helps reduce diff noise if/when these change and brings these in line with the wrapping elsewhere in this codebase.

Ideally we'd add a linter for this, however I'm not aware of any which do quite what's desired. https://pypi.org/project/flake8-multiline-containers/ is pretty close, but doesn't allow hugging:
``` python
foo(bar(
    arg,
    arg2,
))
```
which we do allow and use quite a bit.