### PR TITLE
Remove a bunch of type `cast` calls which we can avoid

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -183,6 +183,10 @@ def get_simulation_run_mode(supervisor: Supervisor) -> 'SimulationMode':
         return Supervisor.SIMULATION_MODE_FAST
 
 
+def inform_start(node: Node) -> None:
+    node.getField('customData').setSFString('start')
+
+
 def run_match(supervisor: Supervisor) -> None:
     print("===========")
     print("Match start")
@@ -190,8 +194,8 @@ def run_match(supervisor: Supervisor) -> None:
 
     # First signal the robot controllers that they're able to start ...
     for _, robot in get_robots(supervisor, skip_missing=True):
-        robot.getField('customData').setSFString('start')
-    cast(Node, supervisor.getFromDef('WALL_CTRL')).getField('customData').setSFString('start')
+        inform_start(robot)
+    inform_start(cast(Node, supervisor.getFromDef('WALL_CTRL')))
 
     # ... then un-pause the simulation, so they all start together
     supervisor.simulationSetMode(get_simulation_run_mode(supervisor))

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -1,7 +1,7 @@
 import sys
 import time
 import contextlib
-from typing import cast, List, Tuple, Iterator, TYPE_CHECKING
+from typing import List, Tuple, Iterator, TYPE_CHECKING
 from pathlib import Path
 
 import pkg_resources
@@ -195,7 +195,7 @@ def run_match(supervisor: Supervisor) -> None:
     # First signal the robot controllers that they're able to start ...
     for _, robot in get_robots(supervisor, skip_missing=True):
         inform_start(robot)
-    inform_start(cast(Node, supervisor.getFromDef('WALL_CTRL')))
+    inform_start(controller_utils.node_from_def(supervisor, 'WALL_CTRL'))
 
     # ... then un-pause the simulation, so they all start together
     supervisor.simulationSetMode(get_simulation_run_mode(supervisor))

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -2,7 +2,7 @@ import sys
 import enum
 import struct
 import logging
-from typing import Set, cast, Dict, List, Tuple, Union
+from typing import Set, Dict, List, Tuple, Union
 from pathlib import Path
 from collections import defaultdict
 
@@ -150,17 +150,13 @@ class AttachedTerritories:
             Union[StationCode, TerritoryRoot], Set[StationCode],
         ] = defaultdict(set)
 
-        for link_codes in TERRITORY_LINKS:
-            for index in range(2):
-                # links with stations at both ends are reversable
-                adjacent_zones[link_codes[index]].add(
-                    cast(StationCode, link_codes[1 - index]),
-                )
+        for source, dest in TERRITORY_LINKS:
+            adjacent_zones[source].add(dest)
 
-                if isinstance(link_codes[0], TerritoryRoot):
-                    # links back to starting zones are omitted
-                    # since starting zones cannot be captured
-                    break
+            # Links with stations at both ends are reversable, but links from
+            # starting zones are only usefully considered in one direction.
+            if isinstance(source, StationCode):
+                adjacent_zones[dest].add(source)
 
         return adjacent_zones
 

--- a/controllers/wall_controller/wall_controller.py
+++ b/controllers/wall_controller/wall_controller.py
@@ -1,8 +1,7 @@
 import sys
-from typing import cast, List
 from pathlib import Path
 
-from controller import Node, Supervisor
+from controller import Supervisor
 
 # Velocity matrices contain linear and rotational velocities [x, y, z, rot_x, rot_y, rot_z]
 # -0.3m/s is used since the wall is 0.3m tall
@@ -19,9 +18,9 @@ import controller_utils  # isort:skip
 def move_walls_after(seconds: int) -> None:
     robot = Supervisor()
     timestep = robot.getBasicTimeStep()
-    walls: List[Node] = [
-        cast(Node, robot.getFromDef('west_moving_wall')),
-        cast(Node, robot.getFromDef('east_moving_wall')),
+    walls = [
+        controller_utils.node_from_def(robot, 'west_moving_wall'),
+        controller_utils.node_from_def(robot, 'east_moving_wall'),
     ]
 
     if controller_utils.get_robot_mode() == 'comp':

--- a/modules/controller_utils/__init__.py
+++ b/modules/controller_utils/__init__.py
@@ -5,6 +5,8 @@ import datetime
 from typing import IO, Dict, List, Optional, NamedTuple
 from pathlib import Path
 
+from controller import Node, Supervisor
+
 # Root directory of the SR webots simulator (equivalent to the root of the git repo)
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -248,3 +250,10 @@ def tee_streams(name: Path, prefix: str = '') -> None:
         log_file,
         prefix=prefix,
     )
+
+
+def node_from_def(supervisor: Supervisor, name: str) -> Node:
+    node = supervisor.getFromDef(name)
+    if node is None:
+        raise ValueError(f"Unable to fetch node {name!r} from Webots")
+    return node

--- a/modules/sr/robot/utils.py
+++ b/modules/sr/robot/utils.py
@@ -1,4 +1,4 @@
-from typing import cast, Type, TypeVar, Optional
+from typing import Type, TypeVar, Optional
 
 from controller import (
     LED,
@@ -48,4 +48,4 @@ def get_robot_device(robot: Robot, name: str, kind: Type[TDevice]) -> TDevice:
             device = robot.getTouchSensor(name)
     if not isinstance(device, kind):
         raise TypeError
-    return cast(TDevice, device)
+    return device


### PR DESCRIPTION
`cast` is intended to be reserved for places where a type checker cannot determine (either through bugs or inherent limitations) that a given statement is correct, or other similar cases where the programmer can prove something correct that the type checker does not know.

Unfortunately we have gathered a few uses of it which are instead just covering the fact that we don't want to do the proper checks or spell the code such that it can be checked properly. This is a bad practise because it weakens the power of the type checker to help identify issues.
We also have one case where the cast is already redundant, but `mypy` isn't alerting about that redundancy. (This itself might be a bug in mypy).

This PR fixes these through a mixture of adding helpers to do the value checks we ought to be doing and reworking the code so that it can be type checked. In all cases the resulting code is clearer in intent as well as being safer.

Suggest review by commit.