### PR TITLE
Separate out the Webots wrappers from our other utils

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -16,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(1, str(REPO_ROOT / 'modules'))
 
 import controller_utils  # isort:skip
+import webots_utils  # isort:skip
 
 
 @contextlib.contextmanager
@@ -195,7 +196,7 @@ def run_match(supervisor: Supervisor) -> None:
     # First signal the robot controllers that they're able to start ...
     for _, robot in get_robots(supervisor, skip_missing=True):
         inform_start(robot)
-    inform_start(controller_utils.node_from_def(supervisor, 'WALL_CTRL'))
+    inform_start(webots_utils.node_from_def(supervisor, 'WALL_CTRL'))
 
     # ... then un-pause the simulation, so they all start together
     supervisor.simulationSetMode(get_simulation_run_mode(supervisor))

--- a/controllers/wall_controller/wall_controller.py
+++ b/controllers/wall_controller/wall_controller.py
@@ -13,14 +13,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(1, str(REPO_ROOT / 'modules'))
 
 import controller_utils  # isort:skip
+import webots_utils  # isort:skip
 
 
 def move_walls_after(seconds: int) -> None:
     robot = Supervisor()
     timestep = robot.getBasicTimeStep()
     walls = [
-        controller_utils.node_from_def(robot, 'west_moving_wall'),
-        controller_utils.node_from_def(robot, 'east_moving_wall'),
+        webots_utils.node_from_def(robot, 'west_moving_wall'),
+        webots_utils.node_from_def(robot, 'east_moving_wall'),
     ]
 
     if controller_utils.get_robot_mode() == 'comp':

--- a/modules/controller_utils/__init__.py
+++ b/modules/controller_utils/__init__.py
@@ -1,11 +1,13 @@
+"""
+Utilities for our controllers which relate to the running of matches.
+"""
+
 import os
 import sys
 import json
 import datetime
 from typing import IO, Dict, List, Optional, NamedTuple
 from pathlib import Path
-
-from controller import Node, Supervisor
 
 # Root directory of the SR webots simulator (equivalent to the root of the git repo)
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -250,10 +252,3 @@ def tee_streams(name: Path, prefix: str = '') -> None:
         log_file,
         prefix=prefix,
     )
-
-
-def node_from_def(supervisor: Supervisor, name: str) -> Node:
-    node = supervisor.getFromDef(name)
-    if node is None:
-        raise ValueError(f"Unable to fetch node {name!r} from Webots")
-    return node

--- a/modules/webots_utils/__init__.py
+++ b/modules/webots_utils/__init__.py
@@ -1,0 +1,15 @@
+"""
+General utilities which wrap Webots' APIs.
+
+These are separate to avoid forcing a dependency on Webots within consumers of
+our `controller_utils`.
+"""
+
+from controller import Node, Supervisor
+
+
+def node_from_def(supervisor: Supervisor, name: str) -> Node:
+    node = supervisor.getFromDef(name)
+    if node is None:
+        raise ValueError(f"Unable to fetch node {name!r} from Webots")
+    return node


### PR DESCRIPTION
This breaks a dependency from `run-comp-match` to Webots controller API.

I'm tempted to rename `controller_utils` to `match_utils`, but have left that for now so this PR can be a targetted fix for the current `master` breakage.