### PR TITLE
Fix mass ratio warnings

### DIFF
--- a/protos/Robot_Echo/SRRobot.proto
+++ b/protos/Robot_Echo/SRRobot.proto
@@ -516,7 +516,8 @@ PROTO SRRobot [
           }
           name "right wheel spacer"
           physics Physics {
-            density 0.1
+            density -1
+            mass 0.001
           }
         }
         DEF LEFT_WHEEL HingeJoint {
@@ -711,7 +712,8 @@ PROTO SRRobot [
           }
           name "left wheel spacer"
           physics Physics {
-            density 0.1
+            density -1
+            mass 0.001
           }
         }
       ]


### PR DESCRIPTION
The extreme mass ratio between the wheel spacer and robot body causes a physics warning to be raised.
SInce the spacer is not attached to the axle and does not rotate it's mass won't effect the movement of the wheel.
This changes from using an arbitrary density to a fixed mass of 1 gram for each spacer.