### PR TITLE
Stop territory labels obscuring the territory ownership in animations

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -254,7 +254,7 @@ def configure_territory_display(display: Display, station_code: StationCode) -> 
     display.setAlpha(1)
     display.setColor(0x3270ed)
     display.setFont('Arial Black', 48, True)
-    display.drawText(station_code.value, 80, 160)
+    display.drawText(station_code.value, 5, 2)
 
 
 def set_node_colour(node: Node, colour: Tuple[float, float, float]) -> None:

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -248,7 +248,7 @@ def configure_territory_display(display: Display, station_code: StationCode) -> 
 
     # Give the text a tranparent backgorund
     display.setAlpha(0)
-    display.fillRectangle(0, 0, display.getHeight(), display.getWidth())
+    display.fillRectangle(0, 0, display.getWidth(), display.getHeight())
 
     # Add the label
     display.setAlpha(1)

--- a/protos/Territories/SRTerritory.proto
+++ b/protos/Territories/SRTerritory.proto
@@ -35,9 +35,7 @@ PROTO SRTerritory [
                   children [
                     Shape {
                       appearance PBRAppearance {
-                        baseColor 0.34191456 0.34191436 0.34191447
-                        roughness 1
-                        metalness 0
+                        baseColor 1 1 1
                         baseColorMap ImageTexture {}
                       }
                       geometry Plane {

--- a/protos/Territories/SRTerritory.proto
+++ b/protos/Territories/SRTerritory.proto
@@ -29,9 +29,9 @@ PROTO SRTerritory [
                 }
                 Display {
                   name IS territoryName
-                  translation 0 0.005 0
-                  height 256
-                  width 256
+                  translation 0 0.005 0.25
+                  height 55
+                  width 120
                   children [
                     Shape {
                       appearance PBRAppearance {
@@ -40,9 +40,8 @@ PROTO SRTerritory [
                         metalness 0
                         baseColorMap ImageTexture {}
                       }
-                      geometry DEF TERRITORY Cylinder {
-                          height 0.001
-                          radius 0.5
+                      geometry Plane {
+                        size 0.5 0.25
                       }
                     }
                   ]


### PR DESCRIPTION
The output of displays are not rendered in the produced animations. As such the current labels are rendered as an opaque disk over the territory floor so the owner's colour is not visible.

This reduces the display to the area used by the labels so that the territory floor is still visible in the animations. If we want to have the labels visible in the animation outputs we will have to generate the labels as textures.

![2021-02-11-200041_1876x698_scrot](https://user-images.githubusercontent.com/10937272/107847982-0ba2f000-6de8-11eb-9ecd-b87efa8fce5e.png)
