### PR TITLE
Remove unnecessary textures

### DIFF
--- a/protos/Robot_Echo/SRRobot.proto
+++ b/protos/Robot_Echo/SRRobot.proto
@@ -439,22 +439,7 @@ PROTO SRRobot [
                     ]
                   }
                   roughness 0.9
-                  roughnessMap ImageTexture {
-                    url [
-                      "./textures/cyberbotics/smooth_rubber_roughness.jpg"
-                    ]
-                  }
                   metalness 0
-                  normalMap ImageTexture {
-                    url [
-                      "./textures/cyberbotics/smooth_rubber_normal.jpg"
-                    ]
-                  }
-                  occlusionMap ImageTexture {
-                    url [
-                      "./textures/cyberbotics/smooth_rubber_occlusion.jpg"
-                    ]
-                  }
                 }
                 geometry IndexedFaceSet {
                   coord DEF coord_LEFT_TIRE Coordinate {
@@ -634,22 +619,7 @@ PROTO SRRobot [
                     ]
                   }
                   roughness 0.9
-                  roughnessMap ImageTexture {
-                    url [
-                      "./textures/cyberbotics/smooth_rubber_roughness.jpg"
-                    ]
-                  }
                   metalness 0
-                  normalMap ImageTexture {
-                    url [
-                      "./textures/cyberbotics/smooth_rubber_normal.jpg"
-                    ]
-                  }
-                  occlusionMap ImageTexture {
-                    url [
-                      "./textures/cyberbotics/smooth_rubber_occlusion.jpg"
-                    ]
-                  }
                 }
                 geometry IndexedFaceSet {
                   coord DEF coord_LEFT_TIRE Coordinate {

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -12,12 +12,11 @@ Viewpoint {
 TexturedBackgroundLight {
   texture "noon_park_empty"
 }
-TexturedBackground {
-  texture "noon_park_empty"
-  skybox FALSE
+Background {
   skyColor [
     0.960784 0.952941 0.956863
   ]
+  luminosity 0.35
 }
 
 # Updating colours? Update `territory_controller.py`
@@ -305,8 +304,10 @@ Transform {
       translation 0 -0.001 0
       children [
         Shape {
-          appearance MattePaint {
+          appearance PBRAppearance {
             baseColor 0.6 0.6 0.6
+            roughness 1
+            metalness 0
           }
           geometry Plane {
             size 10 5


### PR DESCRIPTION
Reduces animation textures from 3.46MB to 206kB.

Removes roughness, normal and occulusion maps for wheels and changes the floor and background from a texture to fixed colour.