### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run match
         run: |
           source ./venv/bin/activate
-          xvfb-run script/run-comp-match archives 42 - ABC --duration 5
+          xvfb-run script/run-comp-match archives 42 - ABC --duration 5 --resolution 1280 720
       - name: Store archives
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -22,6 +22,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update
           sudo apt-get install --yes wget zip pulseaudio xvfb
+          pulseaudio -D
       - name: Download Webots
         run: |
           wget -O ./webots.deb \

--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run match
         run: |
           source ./venv/bin/activate
-          xvfb-run script/run-comp-match archives 42 - ABC --duration 5 --no-record
+          xvfb-run script/run-comp-match archives 42 - ABC --duration 5
       - name: Store archives
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,12 @@ jobs:
           echo "# $f" >> all-requirements.txt
           cat $f >> all-requirements.txt
         done
+    - name: Patch Windows python3
+      if: matrix.test-os == 'windows-latest'
+      run: |
+        if ! command -v python3 &> /dev/null; then
+          ln -s $(which python) /usr/bin/python3
+        fi
     - name: Cache dependencies
       uses: actions/cache@v2
       id: cache-dep

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -33,7 +33,7 @@ def construct_match_data(args: argparse.Namespace) -> controller_utils.MatchData
     ]
 
     recording_config = controller_utils.RecordingConfig(
-        resolution=controller_utils.Resolution(args.resolution[0], args.resolution[1]),
+        resolution=controller_utils.Resolution(*args.resolution),
         quality=100,
     )
 

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -32,12 +32,14 @@ def construct_match_data(args: argparse.Namespace) -> controller_utils.MatchData
         for tla in args.tla
     ]
 
-    recording_config = None  # use the default
+    recording_config = controller_utils.RecordingConfig(
+        resolution=controller_utils.Resolution(args.resolution[0], args.resolution[1]),
+        quality=100,
+    )
+
     if args.no_record:
-        recording_config = controller_utils.RecordingConfig(
-            resolution=controller_utils.Resolution(0, 0),  # the resolution is unused
-            quality=0,  # signal to the competition_supervisor to not generate a video
-        )
+        # signal to the competition_supervisor to not generate a video
+        recording_config = recording_config._replace(quality=0)
 
     return controller_utils.MatchData(
         args.match_num,
@@ -231,6 +233,14 @@ def parse_args() -> argparse.Namespace:
         ),
         action='store_true',
         dest='no_record',
+    )
+    parser.add_argument(
+        '--resolution',
+        help="Set the resolution of the produced video. The format is <width> <height>",
+        type=int,
+        nargs=2,
+        default=[1920, 1080],
+        metavar=('width', 'height'),
     )
     return parser.parse_args()
 

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -34,12 +34,9 @@ def construct_match_data(args: argparse.Namespace) -> controller_utils.MatchData
 
     recording_config = controller_utils.RecordingConfig(
         resolution=controller_utils.Resolution(*args.resolution),
-        quality=100,
+        # signal to the competition_supervisor to not generate a video when no_record is set
+        quality=0 if args.no_record else 100,
     )
-
-    if args.no_record:
-        # signal to the competition_supervisor to not generate a video
-        recording_config = recording_config._replace(quality=0)
 
     return controller_utils.MatchData(
         args.match_num,

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -236,7 +236,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         '--resolution',
-        help="Set the resolution of the produced video. The format is <width> <height>",
+        help="Set the resolution of the produced video.",
         type=int,
         nargs=2,
         default=[1920, 1080],


### PR DESCRIPTION
This fixes several shortcomings with the current CI setup:
- Re-enables recording video while running the test match
- Adds support to `run-comp-match` for setting the video resolution (This notabably reduces CI run time)
- Fixes pulseaudio being unavailable, which delayed Webots starting
- Disables camera and display overlays so that the arena is not obscured in the test videos
- Fixes an intermittent bug where Windows doesn't map `python3` to `python`