### PR TITLE
Use runpy rather than exec

### DIFF
--- a/controllers/sr_controller/sr_controller.py
+++ b/controllers/sr_controller/sr_controller.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import runpy
 import subprocess
 from shutil import copyfile
 from pathlib import Path
@@ -145,7 +146,7 @@ def main() -> None:
     # Swith to running the competitor code
     reconfigure_environment(robot_file)
 
-    exec(robot_file.read_text(), {})
+    runpy.run_path(str(robot_file))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The [`runpy` package](https://docs.python.org/3/library/runpy.html) is what implements `python -m X.py` and `python X.py` running, so it's pretty much designed for what we're trying to do here.

The main reason to switch to it is that it preserves the original file name of the code being run and thus plays much better with debuggers.