### PR TITLE
Improve ClaimLog class data format

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -5,7 +5,7 @@ import enum
 import struct
 import logging
 import collections
-from typing import Set, Dict, List, Tuple, Union, Mapping, NamedTuple
+from typing import Set, Dict, List, Tuple, Union, Mapping
 from pathlib import Path
 from collections import defaultdict
 from dataclasses import dataclass
@@ -113,7 +113,8 @@ class StationStatus:
     locked: bool = False
 
 
-class ClaimLogEntry(NamedTuple):
+@dataclass(frozen=True)
+class ClaimLogEntry:
     station_code: StationCode
     claimant: Claimant
     claim_time: float

--- a/controllers/territory_controller/tests.py
+++ b/controllers/territory_controller/tests.py
@@ -35,11 +35,11 @@ class TestAttachedTerritories(unittest.TestCase):
     def load_territory_owners(self, claim_log: ClaimLog) -> None:
         # territories BG, TS, OX, VB, BE, SZ owned by zone 0
         for territory in self._zone_0_territories:
-            claim_log._station_statuses[territory] = Claimant.ZONE_0
+            claim_log._station_statuses[territory].owner = Claimant.ZONE_0
 
         # territories PN, EY, PO, YL owned by zone 1
         for territory in self._zone_1_territories:
-            claim_log._station_statuses[territory] = Claimant.ZONE_1
+            claim_log._station_statuses[territory].owner = Claimant.ZONE_1
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Converts `ClaimLogEntry` to `NamedTuple` and combines `_station_statuses` and `_locked_territories` into a single `dataclass`.