### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -1,7 +1,10 @@
 name: Simulator match
 
 on:
-  push: {}
+  push:
+    branches:
+      - master
+  pull_request: {}
   release:
     types: [ created ]
 

--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -12,15 +12,14 @@ jobs:
   skip_duplicates:
     continue-on-error: true
     runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.3.0
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
 
   run-comp-match:
     needs: skip_duplicates
-    if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -9,7 +9,18 @@ on:
     types: [ created ]
 
 jobs:
+  skip_duplicates:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.3.0
+
   run-comp-match:
+    needs: skip_duplicates
+    if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,14 @@ jobs:
   skip_duplicates:
     continue-on-error: true
     runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.3.0
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
 
   run-checks:
     needs: skip_duplicates
-    if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,18 @@ on:
   pull_request: {}
 
 jobs:
+  skip_duplicates:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.3.0
+
   run-checks:
+    needs: skip_duplicates
+    if: ${{ needs.skip_duplicates.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,10 @@
 name: Simulator tests
 
 on:
-  push: {}
+  push:
+    branches:
+      - master
+  pull_request: {}
 
 jobs:
   run-checks:


### PR DESCRIPTION
This limits CI to running on PRs and the `master` branch and auto cancels redundant builds.
i.e. if you push another commit before the previous workflow has completed the old workflow is cancelled. Also when a new commit is created which adds no new content over previous commits (merge commit, etc.) the CI is skipped with a link to the completed run.

Currently running on PRs occurs when:
- the pull request is created
- commit(s) are pushed to the pull request
- a closed pull request is reopened