### PR TITLE
Change publish workflow to auto-create releases from tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    # using v2 strips tag annotations https://github.com/actions/checkout/issues/290
+    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,16 @@
 name: Publish simulator archive
 
 on:
-  release:
-    types: [ published ]
+  push:
+    tags:
+      - '**'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    # checkout@v1 must be used since v2 breaks tags
+    - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
@@ -20,12 +22,16 @@ jobs:
         NAME="competition-simulator-$(git describe --always --tags).zip"
         ./script/create-archive --output archive/$NAME
         echo "##[set-output name=archive;]$NAME"
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v1-release
+    - name: Get tag annotation
+      uses: ericcornelissen/git-tag-annotation-action@v1
+      id: tag_data
+    - name: Do release with binaries
+      uses: ncipollo/release-action@v1
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: archive/${{ steps.build_archive.outputs.archive }}
-        asset_name: ${{ steps.build_archive.outputs.archive }}
-        tag: ${{ github.ref }}
-        overwrite: true
-
+        token: ${{ secrets.GITHUB_TOKEN }}
+        allowUpdates: true
+        body: ${{ steps.tag_data.outputs.git-tag-annotation }}
+        artifact: archive/${{ steps.build_archive.outputs.archive }}
+        omitBodyDuringUpdate: true
+        omitNameDuringUpdate: true
+        # replacesArtifacts: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # checkout@v1 must be used since v2 breaks tags
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    # checkout@v1 must be used since v2 breaks tags
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -36,4 +35,3 @@ jobs:
         artifact: archive/${{ steps.build_archive.outputs.archive }}
         omitBodyDuringUpdate: true
         omitNameDuringUpdate: true
-        # replacesArtifacts: true


### PR DESCRIPTION
The release name uses the tag name and the tag annotation is used for the release text.

This also still supports creating releases from the Github UI as long as it doesn't use an existing tag.