### PR TITLE
Arena Lighting Effects

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -204,6 +204,7 @@ def run_match(supervisor: Supervisor) -> None:
     for _, robot in get_robots(supervisor, skip_missing=True):
         inform_start(robot)
     inform_start(webots_utils.node_from_def(supervisor, 'WALL_CTRL'))
+    inform_start(webots_utils.node_from_def(supervisor, 'LIGHT_CTRL'))
 
     # ... then un-pause the simulation, so they all start together
     supervisor.simulationSetMode(get_simulation_run_mode(supervisor))

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -38,7 +38,7 @@ class LightingEffect(NamedTuple):
             for light in self.lighting
         ]
         return (
-            f"<LightingEffect: \"{self.name}\", "
+            f"<LightingEffect: {self.name!r}, "
             f"start={self.start_time}, fade={self.fade_time}, "
             f"lum={self.luminosity}, "
             f"{', '.join(lights_info)}"

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -20,7 +20,7 @@ import webots_utils  # isort:skip
 
 class ArenaLighting(NamedTuple):
     lightDef: str
-    intensity: float = 0.35
+    intensity: float = 3.5
     colour: Tuple[float, float, float] = (1, 1, 1)
 
 
@@ -100,10 +100,11 @@ class LightingController:
         self.light_nodes: Dict[str, Node] = {}
         for cue in cue_stack:
             for light in cue.lighting:
-                self.light_nodes[light.lightDef] = webots_utils.node_from_def(
-                    self._robot,
-                    light.lightDef,
-                )
+                if self.light_nodes.get(light.lightDef) is None:
+                    self.light_nodes[light.lightDef] = webots_utils.node_from_def(
+                        self._robot,
+                        light.lightDef,
+                    )
 
     def set_node_luminosity(self, node: Node, luminosity: float) -> None:
         node.getField('luminosity').setSFFloat(luminosity)

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -75,8 +75,8 @@ CUE_STACK = [
     LightingEffect(0, fade_time=1.5, name="Fade-up"),
     LightingEffect(
         -0.1,
-        lighting=[ArenaLighting('SUN', colour=(1, 0, 0))],
-        luminosity=0.5,
+        lighting=[ArenaLighting('SUN', intensity=1, colour=(1, 0, 0))],
+        luminosity=0.05,
         name="End of match",
     ),
 ]

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -1,0 +1,176 @@
+"""
+The controller for altering arena lighting provided by a DirectionalLight and a Background
+Currently doesn't support:
+- Overlapping lighting fades
+- Timed pre-match lighting changes
+"""
+import sys
+from typing import List, Tuple, Optional, NamedTuple
+from pathlib import Path
+
+from controller import Node, Supervisor
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+sys.path.insert(1, str(REPO_ROOT / 'modules'))
+
+import controller_utils  # isort:skip
+import webots_utils  # isort:skip
+
+
+class ArenaLighting(NamedTuple):
+    intensity: float = 3.5
+    colour: Tuple[float, float, float] = (1, 1, 1)
+    luminosity: float = 0.35
+
+
+class LightingEffect(NamedTuple):
+    start_time: float  # Negative start times are relative to the end of the match
+    # Negative values 0 - (-0.08) don't get included in the produced recordings
+    fade_time: Optional[float] = None
+    lighting: ArenaLighting = ArenaLighting()
+    name: str = ""
+
+    def __repr__(self) -> str:
+        return (
+            f"<LightingEffect: \"{self.name}\", "
+            f"start={self.start_time}, fade={self.fade_time}, "
+            f"int={self.lighting.intensity}, col={self.lighting.colour}, "
+            f"lum={self.lighting.intensity}>"
+        )
+
+
+CUE_STACK = [
+    LightingEffect(0, lighting=ArenaLighting(intensity=1, luminosity=0.15), name="Pre-set"),
+    LightingEffect(0, fade_time=3, name="Fade-up"),
+    LightingEffect(-0.1, lighting=ArenaLighting(colour=(1, 0, 0)), name="End of match"),
+]
+
+
+class LightingController:
+    def __init__(self, duration: float, cue_stack: List[LightingEffect]) -> None:
+        self._robot = Supervisor()
+        self.timestep = self._robot.getBasicTimeStep()
+        self.start_offset: float = 0
+
+        self.duration = duration
+        self.cue_stack = cue_stack
+
+        self.sun_node = webots_utils.node_from_def(self._robot, 'SUN')
+        self.ambient_node = webots_utils.node_from_def(self._robot, 'AMBIENT')
+
+    def set_node_luminosity(self, node: Node, luminosity: float) -> None:
+        node.getField('luminosity').setSFFloat(luminosity)
+
+    def set_node_intensity(self, node: Node, intensity: float) -> None:
+        node.getField('intensity').setSFFloat(intensity)
+
+    def set_node_colour(self, node: Node, colour: Tuple[float, float, float]) -> None:
+        node.getField('color').setSFColor(list(colour))
+
+    def get_current_lighting_values(self) -> ArenaLighting:
+        return ArenaLighting(
+            self.sun_node.getField('intensity').getSFFloat(),
+            tuple(self.sun_node.getField('color').getSFColor()),  # type: ignore
+            self.ambient_node.getField('luminosity').getSFFloat(),
+        )
+
+    def increment_colour(
+        self,
+        colour: Tuple[float, float, float],
+        step: Tuple[float, float, float],
+    ) -> Tuple[float, float, float]:
+        return tuple(colour[i] + step[i] for i in range(3))  # type: ignore
+
+    def current_match_time(self) -> float:
+        return self._robot.getTime() - self.start_offset
+
+    def remaining_match_time(self) -> float:
+        return self.duration - self.current_match_time()
+
+    def do_lighting_effect(self, effect: LightingEffect) -> None:
+        print(  # noqa: T001
+            f"Running lighting effect: {effect.name} @ {self.current_match_time()}",
+        )
+
+        if effect.fade_time is None:
+            self.set_node_intensity(self.sun_node, effect.lighting.intensity)
+            self.set_node_colour(self.sun_node, effect.lighting.colour)
+            self.set_node_luminosity(self.ambient_node, effect.lighting.luminosity)
+        else:
+            (  # get starting values
+                current_intensity,
+                current_colour,
+                current_luminosity,
+            ) = self.get_current_lighting_values()
+
+            # figure out steps of each value
+            steps = int((effect.fade_time * 1000) / self.timestep)
+            intensity_step = (effect.lighting.intensity - current_intensity) / steps
+            colour_step: Tuple[float, float, float] = tuple(  # type: ignore
+                effect.lighting.colour[i] - current_colour[i]
+                for i in range(3)
+            )
+            luminosity_step = (effect.lighting.luminosity - current_luminosity) / steps
+
+            for step in range(steps - 1):  # loop through for fade time
+                self.set_node_intensity(self.sun_node, current_intensity)
+                self.set_node_colour(self.sun_node, current_colour)
+                self.set_node_luminosity(self.ambient_node, current_luminosity)
+
+                current_intensity += intensity_step
+                current_colour = self.increment_colour(current_colour, colour_step)
+                current_luminosity += luminosity_step
+                self._robot.step(int(self.timestep))
+
+            # directly set final values to remove accumulated errors
+            self.set_node_intensity(self.sun_node, effect.lighting.intensity)
+            self.set_node_colour(self.sun_node, effect.lighting.colour)
+            self.set_node_luminosity(self.ambient_node, effect.lighting.luminosity)
+
+            print(f"Lighting effect '{effect.name}' complete")  # noqa: T001
+
+    def schedule_lighting(self) -> None:
+        if controller_utils.get_robot_mode() != 'comp':
+            return
+
+        print('Scheduled cues:')  # noqa: T001
+        for cue in self.cue_stack:
+            print(cue)  # noqa: T001
+
+        # run pre-start snap changes
+        for cue in self.cue_stack:
+            if cue.start_time == 0 and cue.fade_time is None:
+                self.do_lighting_effect(cue)
+                self.cue_stack.remove(cue)
+
+        # Interact with the supervisor "robot" to wait for the start of the match.
+        while self._robot.getCustomData() != 'start':
+            self._robot.step(int(self.timestep))
+
+        self.start_offset = self._robot.getTime()
+
+        while self.cue_stack:
+            for cue in self.cue_stack:
+                if (
+                    cue.start_time >= 0 and
+                    self.current_match_time() >= cue.start_time
+                ):  # cue relative to start
+                    self.do_lighting_effect(cue)
+                    self.cue_stack.remove(cue)
+                elif (
+                    cue.start_time < 0 and
+                    self.remaining_match_time() <= -(cue.start_time)
+                ):  # cue relative to end
+                    self.do_lighting_effect(cue)
+                    self.cue_stack.remove(cue)
+
+                self._robot.step(int(self.timestep))
+
+
+if __name__ == "__main__":
+    lighting_controller = LightingController(
+        controller_utils.get_match_duration_seconds(),
+        CUE_STACK,
+    )
+    lighting_controller.schedule_lighting()

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -232,7 +232,7 @@ class LightingController:
             print(cue)  # noqa: T001
 
         # run pre-start snap changes
-        for cue in self.cue_stack:
+        for cue in self.cue_stack.copy():
             if cue.start_time == 0 and cue.fade_time is None:
                 self.start_lighting_effect(cue)
                 self.cue_stack.remove(cue)
@@ -244,7 +244,7 @@ class LightingController:
         self.start_offset = self._robot.getTime()
 
         while self.cue_stack:
-            for cue in self.cue_stack:
+            for cue in self.cue_stack.copy():
                 if (
                     cue.start_time >= 0 and
                     self.current_match_time() >= cue.start_time

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -41,9 +41,13 @@ class LightingEffect(NamedTuple):
 
 
 CUE_STACK = [
-    LightingEffect(0, lighting=ArenaLighting(intensity=1, luminosity=0.15), name="Pre-set"),
-    LightingEffect(0, fade_time=3, name="Fade-up"),
-    LightingEffect(-0.1, lighting=ArenaLighting(colour=(1, 0, 0)), name="End of match"),
+    LightingEffect(0, lighting=ArenaLighting(intensity=1, luminosity=0.05), name="Pre-set"),
+    LightingEffect(0, fade_time=1.5, name="Fade-up"),
+    LightingEffect(
+        -0.1,
+        lighting=ArenaLighting(colour=(1, 0, 0), luminosity=0.5),
+        name="End of match",
+    ),
 ]
 
 

--- a/controllers/lighting_controller/lighting_controller.py
+++ b/controllers/lighting_controller/lighting_controller.py
@@ -19,7 +19,7 @@ import webots_utils  # isort:skip
 
 
 class ArenaLighting(NamedTuple):
-    lightDef: str
+    light_def: str
     intensity: float = 3.5
     colour: Tuple[float, float, float] = (1, 1, 1)
 
@@ -34,7 +34,7 @@ class LightingEffect(NamedTuple):
 
     def __repr__(self) -> str:
         lights_info = [
-            f"({light.lightDef}, int={light.intensity}, col={light.colour})"
+            f"({light.light_def}, int={light.intensity}, col={light.colour})"
             for light in self.lighting
         ]
         return (
@@ -100,10 +100,10 @@ class LightingController:
         self.light_nodes: Dict[str, Node] = {}
         for cue in cue_stack:
             for light in cue.lighting:
-                if self.light_nodes.get(light.lightDef) is None:
-                    self.light_nodes[light.lightDef] = webots_utils.node_from_def(
+                if self.light_nodes.get(light.light_def) is None:
+                    self.light_nodes[light.light_def] = webots_utils.node_from_def(
                         self._robot,
-                        light.lightDef,
+                        light.light_def,
                     )
 
     def set_node_luminosity(self, node: Node, luminosity: float) -> None:
@@ -118,10 +118,10 @@ class LightingController:
     def get_current_luminosity(self) -> float:
         return self.ambient_node.getField('luminosity').getSFFloat()
 
-    def get_current_lighting_values(self, lightDef: str) -> ArenaLighting:
-        light = self.light_nodes[lightDef]
+    def get_current_lighting_values(self, light_def: str) -> ArenaLighting:
+        light = self.light_nodes[light_def]
         return ArenaLighting(
-            lightDef,
+            light_def,
             light.getField('intensity').getSFFloat(),
             light.getField('color').getSFColor(),  # type: ignore
         )
@@ -147,8 +147,8 @@ class LightingController:
         if effect.fade_time is None:
             self.set_node_luminosity(self.ambient_node, effect.luminosity)
             for light in effect.lighting:
-                self.set_node_intensity(self.light_nodes[light.lightDef], light.intensity)
-                self.set_node_colour(self.light_nodes[light.lightDef], light.colour)
+                self.set_node_intensity(self.light_nodes[light.light_def], light.intensity)
+                self.set_node_colour(self.light_nodes[light.light_def], light.colour)
 
             print(f"Lighting effect '{effect.name}' complete")  # noqa: T001
 
@@ -171,7 +171,7 @@ class LightingController:
                     _,
                     current_intensity,
                     current_colour,
-                ) = self.get_current_lighting_values(light.lightDef)
+                ) = self.get_current_lighting_values(light.light_def)
 
                 # figure out steps of each value
                 intensity_step = (light.intensity - current_intensity) / steps
@@ -182,7 +182,7 @@ class LightingController:
 
                 # add fade to queue to have steps processed
                 self.lighting_fades.append(LightFade(
-                    self.light_nodes[light.lightDef],
+                    self.light_nodes[light.light_def],
                     steps,
                     intensity_step,
                     colour_step,
@@ -219,7 +219,7 @@ class LightingController:
                 self.set_node_intensity(fade.light, fade.effect.intensity)
                 self.set_node_colour(fade.light, fade.effect.colour)
 
-                print(f"Lighting effect for '{fade.effect.lightDef}' complete")  # noqa: T001
+                print(f"Lighting effect for '{fade.effect.light_def}' complete")  # noqa: T001
 
                 self.lighting_fades.remove(fade)  # remove completed fade
 

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -12,10 +12,13 @@ Viewpoint {
   #position 0 20.5 0
   near 0.1
 }
-TexturedBackgroundLight {
-  texture "noon_park_empty"
+DEF SUN DirectionalLight {
+  color 1 1 1
+  direction 0 -1 0
+  intensity 3.5
+  castShadows TRUE
 }
-Background {
+DEF AMBIENT Background {
   skyColor [
     0.960784 0.952941 0.956863
   ]
@@ -434,6 +437,13 @@ DEF WALL_CTRL Robot {
   name "wall_controller"
   description "A supervisor 'robot' to handle moving walls"
   controller "wall_controller"
+  supervisor TRUE
+}
+DEF LIGHT_CTRL Robot {
+  translation 0 0 0
+  name "lighting_controller"
+  description "A supervisor 'robot' to handle modifying the arena lighting throughout the match"
+  controller "lighting_controller"
   supervisor TRUE
 }
 


### PR DESCRIPTION
Adds beginning and ending lighting. The lighting effects are configured using a cue stack that can support fading other light sources. Doesn't support running lighting effects before the start of the match although it has been noted that these could be recorded as a separate match with a custom cuestack and then stitched together afterwards.

https://user-images.githubusercontent.com/10937272/115083438-423bda80-9eff-11eb-952e-f4f3ff29404c.mp4

Fixes srobo/competition-simulator#17 