### PR TITLE
Make the compass' jitter magnitude independent of its value

### DIFF
--- a/modules/sr/robot/compass.py
+++ b/modules/sr/robot/compass.py
@@ -16,4 +16,4 @@ class Compass:
         """
         x, _, z = self._compass.getValues()
         heading = atan2(x, z) % tau
-        return add_independent_jitter(heading, 0, tau, 0.5, True)
+        return add_independent_jitter(heading, 0, tau, 0.4, True)

--- a/modules/sr/robot/compass.py
+++ b/modules/sr/robot/compass.py
@@ -2,7 +2,7 @@ from math import tau, atan2
 
 from controller import Robot, Compass as WebotsCompass
 from sr.robot.utils import get_robot_device
-from sr.robot.randomizer import add_jitter
+from sr.robot.randomizer import add_independent_jitter
 
 
 class Compass:
@@ -16,4 +16,4 @@ class Compass:
         """
         x, _, z = self._compass.getValues()
         heading = atan2(x, z) % tau
-        return add_jitter(heading, 0, tau)
+        return add_independent_jitter(heading, 0, tau, 0.5, True)

--- a/modules/sr/robot/compass.py
+++ b/modules/sr/robot/compass.py
@@ -16,4 +16,4 @@ class Compass:
         """
         x, _, z = self._compass.getValues()
         heading = atan2(x, z) % tau
-        return add_independent_jitter(heading, 0, tau, 0.4, True)
+        return add_independent_jitter(heading, 0, tau, std_dev_percent=0.4, can_wrap=True)

--- a/modules/sr/robot/randomizer.py
+++ b/modules/sr/robot/randomizer.py
@@ -11,6 +11,9 @@ T = TypeVar('T', float, int)
 # The maximum randomness which can be added in either direction
 DEFAULT_RANDOM_RANGE_PERCENT = 2.5
 
+# The maximum randomness which can be added in either direction, compared to full scale value
+DEFAULT_RANDOM_INDEPENDENT_RANGE_PERCENT = 0.25
+
 
 def add_jitter(
     actual_value: T,
@@ -21,3 +24,21 @@ def add_jitter(
     random_range = actual_value * (random_range_percent / float(100))
     new_value = actual_value + random.uniform(-random_range, random_range)
     return type(actual_value)(max(min_possible, min(new_value, max_possible)))
+
+
+def add_independent_jitter(
+    actual_value: T,
+    min_possible: T,
+    max_possible: T,
+    random_range_percent: float =  # % of full scale value
+    DEFAULT_RANDOM_INDEPENDENT_RANGE_PERCENT,
+    can_wrap: bool = False,
+) -> T:
+    value_range = max_possible - min_possible
+    random_range = value_range * (random_range_percent / float(100))
+    new_value = actual_value + random.uniform(-random_range, random_range)
+    if can_wrap:
+        new_value_normalised = new_value - min_possible
+        return type(actual_value)((new_value_normalised % value_range) + min_possible)
+    else:
+        return type(actual_value)(max(min_possible, min(new_value, max_possible)))

--- a/modules/sr/robot/randomizer.py
+++ b/modules/sr/robot/randomizer.py
@@ -35,8 +35,8 @@ def add_independent_jitter(
     can_wrap: bool = False,
 ) -> T:
     value_range = max_possible - min_possible
-    random_range = value_range * (std_dev_percent / float(100))
-    new_value = random.gauss(actual_value, random_range)
+    std_dev = value_range * (std_dev_percent / float(100))
+    new_value = random.gauss(actual_value, std_dev)
     if can_wrap:
         new_value_normalised = new_value - min_possible
         return type(actual_value)((new_value_normalised % value_range) + min_possible)

--- a/modules/sr/robot/randomizer.py
+++ b/modules/sr/robot/randomizer.py
@@ -30,8 +30,7 @@ def add_independent_jitter(
     actual_value: T,
     min_possible: T,
     max_possible: T,
-    std_dev_percent: float =  # % of full scale value
-    DEFAULT_RANDOM_INDEPENDENT_RANGE_PERCENT,
+    std_dev_percent: float = DEFAULT_RANDOM_INDEPENDENT_RANGE_PERCENT,  # % of full scale value
     can_wrap: bool = False,
 ) -> T:
     value_range = max_possible - min_possible

--- a/modules/sr/robot/randomizer.py
+++ b/modules/sr/robot/randomizer.py
@@ -30,13 +30,13 @@ def add_independent_jitter(
     actual_value: T,
     min_possible: T,
     max_possible: T,
-    random_range_percent: float =  # % of full scale value
+    std_dev_percent: float =  # % of full scale value
     DEFAULT_RANDOM_INDEPENDENT_RANGE_PERCENT,
     can_wrap: bool = False,
 ) -> T:
     value_range = max_possible - min_possible
-    random_range = value_range * (random_range_percent / float(100))
-    new_value = actual_value + random.uniform(-random_range, random_range)
+    random_range = value_range * (std_dev_percent / float(100))
+    new_value = random.gauss(actual_value, random_range)
     if can_wrap:
         new_value_normalised = new_value - min_possible
         return type(actual_value)((new_value_normalised % value_range) + min_possible)


### PR DESCRIPTION
Additionally allows the value to wrap around at the limits.

Currently the jitter is set to ±1.8°.