### PR TITLE
Better territory claim animations

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -594,7 +594,11 @@ class TerritoryController:
         else:
             # map the progress value to the LEDs
             led_progress = min(int(progress * NUM_TOWER_LEDS), NUM_TOWER_LEDS - 1)
-            # led_prev_progress = min(int(prev_progress * NUM_TOWER_LEDS), NUM_TOWER_LEDS - 1)
+            led_prev_progress = min(int(prev_progress * NUM_TOWER_LEDS), NUM_TOWER_LEDS - 1)
+
+            if led_progress == led_prev_progress and prev_progress != 0:
+                # skip setting an LED that was already on
+                return
 
             tower_led = self.get_tower_led(station_code, led_progress)
             tower_led.set(zone_colour)

--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -601,6 +601,17 @@ class TerritoryController:
                 return
 
             tower_led = self.get_tower_led(station_code, led_progress)
+            if led_progress == NUM_TOWER_LEDS - 1:
+                connected_territories = \
+                    self._attached_territories.build_attached_capture_trees()
+                if not self._attached_territories.can_capture_station(
+                    station_code,
+                    claimant,
+                    connected_territories,
+                ):  # station can't be captured by this team, the claim  will fail
+                    # skip setting top LED
+                    return
+
             tower_led.set(zone_colour)
 
     def receive_robot_captures(self) -> None:


### PR DESCRIPTION
Following the friendlies several improvements were suggested, this solves:
- LEDs are only accessed now if they would be changed
- Claims on cut-off towers don't light the top LED
- The tree of connected territories is only updated when it would have changed
  - This makes tests that regularly need whether a territory is claimable much cheaper

Currently the behaviour for a cut-off claim is to not light the top LED. While lighting up a different colour would be clearer the LED colour is additive to the default tower colour. This makes pure red LEDs almost indistinguishable while any other colour will have almost complete red value.

It is recommended to review each commit's diff separately.