### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
     # using v2 strips tag annotations https://github.com/actions/checkout/issues/290
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: '3.10'
 
     - name: Build archive
       id: build_archive

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         test-os: [ubuntu-latest]
         include:
-          - python-version: 3.7
+          - python-version: '3.7'
+            test-os: windows-latest
+          - python-version: '3.10'
             test-os: windows-latest
 
     runs-on: ${{ matrix.test-os }}


### PR DESCRIPTION
We'll be targetting 3.10 for SR2023.

Builds on #346 to avoid conflicts.