### PR TITLE
Validate & update the supported libraries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,10 +86,10 @@ jobs:
       fail-fast: false
       # Changing the supported versions? Also update the checks tasks above.
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         test-os: [ubuntu-latest]
         include:
-          - python-version: '3.7'
+          - python-version: '3.8'
             test-os: windows-latest
           - python-version: '3.10'
             test-os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
     needs: skip_duplicates
     strategy:
       fail-fast: false
+      # Changing the supported versions? Also update the libraries tasks below.
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         test-os: [ubuntu-latest]
@@ -78,3 +79,36 @@ jobs:
         if: ${{ always() }}
         run: |
           ./script/proto-lint worlds/Arena.wbt protos/**/*.proto
+
+  validate-libraries:
+    needs: skip_duplicates
+    strategy:
+      fail-fast: false
+      # Changing the supported versions? Also update the checks tasks above.
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        test-os: [ubuntu-latest]
+        include:
+          - python-version: '3.7'
+            test-os: windows-latest
+          - python-version: '3.10'
+            test-os: windows-latest
+
+    runs-on: ${{ matrix.test-os }}
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: libraries.txt
+
+      - name: Install Libraries
+        run: |
+          pip install -r libraries.txt

--- a/libraries.txt
+++ b/libraries.txt
@@ -8,8 +8,6 @@
 # matches, so we *don't* have the full range of requirements.txt supported
 # syntax available.
 
-matplotlib==3.3.3
-numpy==1.19.3
-pandas==1.1.4
-scikit-learn==0.23.2
-scipy==1.5.4
+matplotlib==3.5.1
+numpy==1.22.3
+pandas==1.4.2


### PR DESCRIPTION
This updates the supported libraries to the versions that it looks will be included in the physical kits. We also drop a couple which aren't going to be on the physical kits.

If teams want those dropped libraries then we'll need to tell them how to build them for their robot, so we can revisit whether we want them in the simulator at that point too.