### PR TITLE
Drop Python 3.7, move minimum to 3.8

### DIFF
--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         test-os: [ubuntu-latest]
         include:
-          - python-version: '3.7'
+          - python-version: '3.8'
             test-os: windows-latest
           - python-version: '3.10'
             test-os: windows-latest

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ In order to run competition matches you'll need to:
    Note: you can change the version of Python which Webots uses from the UI --
    go to "Tools" > "Preferences" > "General" > "Python command".
 
-   We are using Python 3.7, though it shouldn't matter whether it's a system
+   We are using Python 3.8, though it shouldn't matter whether it's a system
    install or a virtual environment.
 
 2. Launch webots and configure it for recordings:


### PR DESCRIPTION
Per decision in Slack:
https://studentrobotics.slack.com/archives/C01CU87V94P/p1664643863983629?thread_ts=1664641945.025519&cid=C01CU87V94P

We'll actually be running on 3.10, however I'm leaving that change to when we move the webots version (#342) since the version of webots spec'd here doesn't support 3.10.