### PR TITLE
Improve robot to better suit SR2023

### DIFF
--- a/controllers/territory_controller/territory_controller.py
+++ b/controllers/territory_controller/territory_controller.py
@@ -5,7 +5,7 @@ import enum
 import struct
 import logging
 import collections
-from typing import Tuple, Mapping, Callable
+from typing import Mapping, Callable
 from pathlib import Path
 from collections import defaultdict
 from dataclasses import dataclass
@@ -489,7 +489,9 @@ class TerritoryController:
         receive_time: float,
     ) -> None:
         try:
-            robot_id, is_conclude = struct.unpack("!BB", packet)  # type: Tuple[int, int]
+            robot_id: int
+            is_conclude: int
+            robot_id, is_conclude = struct.unpack("!BB", packet)
             claimant = Claimant(robot_id)
             operation_args = (station_code, claimant, receive_time)
             if is_conclude:

--- a/protos/Robot_2022/Robot_2022.proto
+++ b/protos/Robot_2022/Robot_2022.proto
@@ -160,7 +160,7 @@ PROTO Robot_2022 [
                   Shape {
                     appearance USE BODY_COLOUR
                     geometry Box {
-                      size 0.03 0.33 0.012
+                      size 0.03 0.4 0.012
                     }
                   }
                 ]
@@ -177,23 +177,23 @@ PROTO Robot_2022 [
                 ]
               }
               DEF body_left_arm Transform {
-                translation -0.075 -0.1525 0.036
+                translation -0.0681 -0.1875 0.036
                 children [
                   Shape {
                     appearance USE BODY_COLOUR
                     geometry Box {
-                      size 0.12 0.025 0.024
+                      size 0.106 0.025 0.024
                     }
                   }
                 ]
               }
               DEF body_right_arm Transform {
-                translation -0.075 0.1525 0.036
+                translation -0.0681 0.1875 0.036
                 children [
                   Shape {
                     appearance USE BODY_COLOUR
                     geometry Box {
-                      size 0.12 0.025 0.024
+                      size 0.106 0.025 0.024
                     }
                   }
                 ]
@@ -206,7 +206,7 @@ PROTO Robot_2022 [
         translation -0.1 0 0.0025
         children [
           DEF LEFT_CASTER Transform {
-            translation 0 0.15 0
+            translation 0 0.187 0
             children [
               DEF CASTER_JOINT BallJoint {
                 jointParameters BallJointParameters {
@@ -257,7 +257,7 @@ PROTO Robot_2022 [
             ]
           }
           DEF RIGHT_CASTER Transform {
-            translation 0 -0.15 0
+            translation 0 -0.187 0
             children [
               DEF CASTER_JOINT BallJoint {
                 jointParameters BallJointParameters {
@@ -293,7 +293,7 @@ PROTO Robot_2022 [
                 }
                 geometry Cylinder {
                   radius 0.004
-                  height 0.3
+                  height 0.37
                   subdivision 12
                   top FALSE
                   bottom FALSE
@@ -302,7 +302,7 @@ PROTO Robot_2022 [
             ]
             name "Support rod 1"
             boundingObject DEF SUPPORT_ROD_GEO Box {
-              size 0.007 0.007 0.3
+              size 0.007 0.007 0.37
             }
             physics Physics {
               density 8000  # steel
@@ -321,7 +321,7 @@ PROTO Robot_2022 [
             }
           }
           DEF GRABBER_LEFT Transform {
-            translation -0.055 -0.13 0
+            translation -0.055 -0.165 0
             children [
               SliderJoint {
                 jointParameters JointParameters {
@@ -347,18 +347,39 @@ PROTO Robot_2022 [
                 endPoint Solid {
                   children [
                     DEF GRIPPER_ARM Transform {
-                      translation -0.065 0 0
+                      translation 0 0 0
                       children [
-                        Shape {
-                          appearance PBRAppearance {
-                            baseColor 0.25 0.35 0.235
-                            roughness 1
-                            metalness 0
-                          }
-                          geometry Box {
-                            size 0.2 0.012 0.05
-                          }
-                        }
+                        DEF GRIPPER_GEOMETRY Group {
+                          children [
+                            DEF long_bit Transform {
+                              translation -0.12 0 0.075
+                              children [
+                                Shape {
+                                  appearance DEF GRABBER_COLOUR PBRAppearance {
+                                    baseColor 0.25 0.35 0.235
+                                    roughness 1
+                                    metalness 0
+                                  }
+                                  geometry Box {
+                                    size 0.16 0.012 0.05
+                                  }
+                                }
+                              ]
+                            }
+                            DEF bit_with_rails Transform {
+                              translation 0 0 0.0425
+                              children [
+                                Shape {
+                                  appearance USE GRABBER_COLOUR
+                                  geometry Box {
+                                    size 0.08 0.012 0.115
+                                  }
+                                }
+                              ]
+                            }
+
+                        ]
+                      }
                       ]
                     }
                     DEF SLIDE_BEARINGS Group {
@@ -392,7 +413,7 @@ PROTO Robot_2022 [
                     }
                   ]
                   name "Gripper slider 1"
-                  boundingObject USE GRIPPER_ARM
+                  boundingObject USE GRIPPER_GEOMETRY
                   physics Physics {
                     # wood = ~700, leave at default
                   }
@@ -401,7 +422,7 @@ PROTO Robot_2022 [
             ]
           }
           DEF GRABBER_RIGHT Transform {
-            translation -0.055 0.13 0
+            translation -0.055 0.165 0
             children [
               SliderJoint {
                 jointParameters JointParameters {
@@ -435,7 +456,7 @@ PROTO Robot_2022 [
                     }
                   ]
                   name "Gripper slider 2"
-                  boundingObject USE GRIPPER_ARM
+                  boundingObject USE GRIPPER_GEOMETRY
                   physics Physics {
                     # wood = ~700, leave at default
                   }
@@ -551,7 +572,7 @@ PROTO Robot_2022 [
           DEF DISTANCE_SENSORS Group {
             children [
               DEF front_left DistanceSensor {
-                translation -0.122 -0.152 0.07
+                translation -0.122 -0.187 0.07
                 type "sonar"
                 numberOfRays 10
                 aperture 0.3
@@ -604,7 +625,7 @@ PROTO Robot_2022 [
                 ]
               }
               DEF front_right DistanceSensor {
-                translation -0.122 0.152 0.07
+                translation -0.122 0.187 0.07
                 type "sonar"
                 numberOfRays 10
                 aperture 0.3

--- a/protos/Robot_2022/Robot_2022.proto
+++ b/protos/Robot_2022/Robot_2022.proto
@@ -525,11 +525,11 @@ PROTO Robot_2022 [
             signalStrengthNoise 0.03
           }
           Camera {
-            translation -0.02 0 0.12
-            rotation 0 0 1 3.14159265
+            translation -0.02 0 0.16
+            rotation -0.1246747 0 0.9921977 3.1415927
             children [
               Transform {
-                translation 0 0 0.006
+                translation 0 0 0.00
                 rotation 0.5773509358554485 0.5773509358554485 0.5773489358556708 2.0944
                 children [
                   Shape {
@@ -545,7 +545,7 @@ PROTO Robot_2022 [
                 translationStep 0.001
               }
               Transform {
-                translation -0.02 0 0.005
+                translation -0.02 0 0.00
                 children [
                   Shape {
                     appearance PBRAppearance {
@@ -559,6 +559,7 @@ PROTO Robot_2022 [
                 ]
               }
             ]
+            fieldOfView 0.82
             width 800
             height 600
             recognition Recognition {

--- a/protos/Robot_2022/Robot_2022.proto
+++ b/protos/Robot_2022/Robot_2022.proto
@@ -377,9 +377,8 @@ PROTO Robot_2022 [
                                 }
                               ]
                             }
-
-                        ]
-                      }
+                          ]
+                        }
                       ]
                     }
                     DEF SLIDE_BEARINGS Group {

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -495,7 +495,7 @@ Solid { # Plinth Centre
   name "Plinth Centre"
 }
 Solid { # Plinth North Arm
-  translation 0 -0.6375 0.0375
+  translation 0 -0.65 0.0375
   children [
     DEF SHAPE Shape {
       appearance PBRAppearance {
@@ -504,7 +504,7 @@ Solid { # Plinth North Arm
         metalness 0
       }
       geometry Box {
-        size 0.05 0.725 0.075
+        size 0.05 0.7 0.075
       }
     }
   ]
@@ -513,7 +513,7 @@ Solid { # Plinth North Arm
   name "Plinth North Arm"
 }
 Solid { # Plinth South Arm
-  translation 0 0.6375 0.0375
+  translation 0 0.65 0.0375
   children [
     DEF SHAPE Shape {
       appearance PBRAppearance {
@@ -522,7 +522,7 @@ Solid { # Plinth South Arm
         metalness 0
       }
       geometry Box {
-        size 0.05 0.725 0.075
+        size 0.05 0.7 0.075
       }
     }
   ]
@@ -531,7 +531,7 @@ Solid { # Plinth South Arm
   name "Plinth South Arm"
 }
 Solid { # Plinth West Arm
-  translation 0.6375 0 0.0375
+  translation 0.65 0 0.0375
   children [
     DEF SHAPE Shape {
       appearance PBRAppearance {
@@ -540,7 +540,7 @@ Solid { # Plinth West Arm
         metalness 0
       }
       geometry Box {
-        size 0.725 0.05 0.075
+        size 0.7 0.05 0.075
       }
     }
   ]
@@ -549,7 +549,7 @@ Solid { # Plinth West Arm
   name "Plinth West Arm"
 }
 Solid { # Plinth East Arm
-  translation -0.625 0 0.0375
+  translation -0.65 0 0.0375
   children [
     DEF SHAPE Shape {
       appearance PBRAppearance {
@@ -558,7 +558,7 @@ Solid { # Plinth East Arm
         metalness 0
       }
       geometry Box {
-        size 0.725 0.05 0.075
+        size 0.7 0.05 0.075
       }
     }
   ]


### PR DESCRIPTION
This change does the following:
- Raise the camera, pan it down, and increase the FOV so it can see over tokens better
- Widen the grabber and raise it so it can reach over the arms of the plinth

Here's a screenshot, including a FOV of the camera.
![image](https://user-images.githubusercontent.com/2551763/209736192-b43da06d-f7c5-401d-ba30-90050d4fa652.png)

Top-down view with a golden token so you can see the clearance:
![image](https://user-images.githubusercontent.com/2551763/209736464-6f5a349f-1c81-4ec6-9f4e-325be8996f45.png)


Side-on view with a bronze token and a camera perspective:
![image](https://user-images.githubusercontent.com/2551763/209736615-d5084404-f37f-4751-b047-677788f5ea93.png)

