### PR TITLE
Add springs to grabber to reduce wobble

### DIFF
--- a/protos/Robot_2022/Robot_2022.proto
+++ b/protos/Robot_2022/Robot_2022.proto
@@ -330,6 +330,7 @@ PROTO Robot_2022 [
                   minStop -0.01
                   position 0
                   springConstant 5
+                  dampingConstant 2
                   staticFriction 20
                 }
                 device [
@@ -431,6 +432,7 @@ PROTO Robot_2022 [
                   minStop -0.01
                   position 0
                   springConstant 5
+                  dampingConstant 2
                   staticFriction 20
                 }
                 device [

--- a/protos/Robot_2022/Robot_2022.proto
+++ b/protos/Robot_2022/Robot_2022.proto
@@ -329,6 +329,7 @@ PROTO Robot_2022 [
                   maxStop 0.124
                   minStop -0.01
                   position 0
+                  springConstant 5
                   staticFriction 20
                 }
                 device [
@@ -429,6 +430,7 @@ PROTO Robot_2022 [
                   maxStop 0.124
                   minStop -0.01
                   position 0
+                  springConstant 5
                   staticFriction 20
                 }
                 device [


### PR DESCRIPTION
Adds springs and dampening to the grabber to reduce wobble when carrying a cube.

Before:
https://user-images.githubusercontent.com/2551763/216776915-68a312e6-22c7-43ec-a87c-ff0608255b42.mp4

After:
https://user-images.githubusercontent.com/2551763/216777038-4f1abb0a-76d7-4303-8d74-492fd9418730.mp4

