### PR TITLE
Allow overridding webots executable

### DIFF
--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -93,7 +93,7 @@ def print_fatal(message: str) -> None:
 def run_match() -> None:
     try:
         subprocess.check_call([
-            'webots',
+            os.environ.get('WEBOTS_EXECUTABLE', 'webots'),
             '--batch',
             '--stdout',
             '--stderr',


### PR DESCRIPTION
Uses WEBOTS_EXECUTABLE enviroment variable.

On MacOS, webots fails to load qt when adding webots to the path but using an absolute path to webots works. Equally in some situations on Windows webots isn't executable. Making it runtime settable ass some flexibility for these situations.