### PR TITLE
Add script to fix animations on windows

### DIFF
--- a/script/fix-animation
+++ b/script/fix-animation
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import re
+import argparse
+
+
+def fix_animation(input: str, output: str) -> None:
+    with open(input) as f:
+        data = f.readlines()
+
+    output_data = []
+    for line in data:
+        if 'stylesheet' in line:
+            match = re.search(r'href="(.*?)"', line)
+            if match is None:
+                output_data.append(line)
+            else:
+                css_name = match[1].replace('\\', '/').split('/')[-1]
+                output_data.append(f'    <link rel="stylesheet" href="{css_name}">\n')
+        elif '<webots-view' in line:
+            match = re.search(
+                r'data-thumbnail=(.*?) .*data-scene=(.*?) .*data-animation=(.*?)>', line)
+            if match is None:
+                output_data.append(line)
+            else:
+                jpg_name = match[1].replace('\\', '/').split('/')[-1]
+                x3d_name = match[2].replace('\\', '/').split('/')[-1]
+                json_name = match[3].replace('\\', '/').split('/')[-1]
+                output_data.append(
+                    f'      <webots-view data-thumbnail={jpg_name} '
+                    f'data-scene={x3d_name} data-animation={json_name}></webots-view>\n',
+                )
+        else:
+            output_data.append(line)
+
+    with open(output, 'w') as f:
+        f.writelines(output_data)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('animation')
+    parser.add_argument('output')
+
+    args = parser.parse_args()
+
+    fix_animation(args.animation, args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Makes absolute paths relative, assumes ancillary files are siblings of the html.

Fixes #378 