### PR TITLE
Move marker visuals 2mm forwards to prevent z-fighting

### DIFF
--- a/protos/Markers/MarkerBase.proto
+++ b/protos/Markers/MarkerBase.proto
@@ -18,19 +18,24 @@ PROTO MarkerBase [
     translation IS translation
     rotation IS rotation
     children [
-      Shape {
-        appearance PBRAppearance {
-          baseColorMap ImageTexture {
-            url IS texture_url
-            repeatS FALSE
-            repeatT FALSE
+      Transform {
+        translation 0 0.0002 0
+        children [
+          Shape {
+            appearance PBRAppearance {
+              baseColorMap ImageTexture {
+                url IS texture_url
+                repeatS FALSE
+                repeatT FALSE
+              }
+              roughness 1
+              metalness 0
+            }
+            geometry DEF MARKER_GEOMETRY Box {
+              size IS visual_size
+            }
           }
-          roughness 1
-          metalness 0
-        }
-        geometry DEF MARKER_GEOMETRY Box {
-          size IS visual_size
-        }
+        ]
       }
     ]
     name IS name


### PR DESCRIPTION
Move the visual element of a marker forwards by 2mm to prevent z-fighting in the recordings. This does not change the detections of the markers at all

Before:

https://user-images.githubusercontent.com/2551763/221275105-136ec474-3d69-453c-9c94-1268e49b7b92.mp4


After:

https://user-images.githubusercontent.com/2551763/221275121-28817437-dbb5-4c9c-9e70-26adc22e5ef5.mp4


fixes #387 