### PR TITLE
Capture the end-of-match screenshot before fade-down

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -222,7 +222,20 @@ def run_match(supervisor: Supervisor) -> None:
     time_step = int(supervisor.getBasicTimeStep())
     duration = controller_utils.get_match_duration_seconds()
     duration_ms = time_step * int(1000 * duration // time_step)
-    supervisor.step(duration_ms)
+
+    START_AT = 15
+    SAVE = 11
+    STOP_BEFORE = 6
+    supervisor.step(duration_ms - time_step * START_AT)
+
+    for i in range(-START_AT, -STOP_BEFORE):
+        if i == -SAVE:
+            supervisor.exportImage(f'/tmp/bees-{i}.jpg', 100)
+        else:
+            supervisor.exportImage('/tmp/throwaway.jpg', 100)
+        supervisor.step(time_step)
+
+    supervisor.step(time_step * STOP_BEFORE)
 
     print("==================")
     print("Game over, pausing")


### PR DESCRIPTION
This changes when we capture the end-of-match screenshot to just before the fade-down rather than afterwards, in order to present a more consistent view of the world relative to the captured video.

It appears that the video itself only captures a frame or two into the red fade-down, meaning that there's up to 80ms between the end of the video and when the post-fade-up screenshot is captured. When comparing that screenshot to the end of the video there can therefore be considerable discrepancies, which are rather unexpected.

With this change we present a more consistent view of the world.