### PR TITLE
Test our code on Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,14 @@ jobs:
       fail-fast: false
       # Changing the supported versions? Also update the libraries tasks below.
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         test-os: [ubuntu-latest]
         include:
           - python-version: '3.8'
             test-os: windows-latest
           - python-version: '3.10'
+            test-os: windows-latest
+          - python-version: '3.11'
             test-os: windows-latest
 
     runs-on: ${{ matrix.test-os }}
@@ -84,12 +86,14 @@ jobs:
       fail-fast: false
       # Changing the supported versions? Also update the checks tasks above.
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         test-os: [ubuntu-latest]
         include:
           - python-version: '3.8'
             test-os: windows-latest
           - python-version: '3.10'
+            test-os: windows-latest
+          - python-version: '3.11'
             test-os: windows-latest
 
     runs-on: ${{ matrix.test-os }}


### PR DESCRIPTION
Even though the versions of Webots we're using don't yet support it, we expect that that will change as we move to newer versions.

Builds on #400 for cleaner CI.