### PR TITLE
Update our promised libraries to recent versions

### DIFF
--- a/libraries.txt
+++ b/libraries.txt
@@ -19,6 +19,7 @@ shapely==2.0.1
 scipy==1.11.2
 scikit-learn==1.3.0
 networkx==3.1
+# Note: deliberately no 'flask' here as it's unlikely to be useful in the simulator
 
 # An extra offered in the simulator
 typing-extensions==4.7.1

--- a/libraries.txt
+++ b/libraries.txt
@@ -16,7 +16,7 @@ pandas==2.0.3
 numpy==1.24.4
 pillow==10.0.0
 shapely==2.0.1
-scipy==1.11.2
+scipy==1.10.1
 scikit-learn==1.3.0
 networkx==3.1
 # Note: deliberately no 'flask' here as it's unlikely to be useful in the simulator

--- a/libraries.txt
+++ b/libraries.txt
@@ -8,7 +8,21 @@
 # matches, so we *don't* have the full range of requirements.txt supported
 # syntax available.
 
-matplotlib==3.5.1
-numpy==1.22.3
-pandas==1.4.2
-typing-extensions==3.10.0.0
+# List from https://github.com/srobo/robot-image/blob/main/files/python/libraries.txt
+matplotlib==3.7.2
+# Note: pandas 2.1 has some known issues, avoid it for now.
+# (https://github.com/pandas-dev/pandas/issues?q=is%3Aissue+is%3Aopen+label%3ARegression)
+pandas==2.0.3
+numpy==1.24.4
+pillow==10.0.0
+shapely==2.0.1
+scipy==1.11.2
+scikit-learn==1.3.0
+networkx==3.1
+
+# An extra offered in the simulator
+typing-extensions==4.7.1
+
+# Needed for matplotlib, pinned as likely useful directly
+contourpy==1.1.0
+kiwisolver==1.4.5


### PR DESCRIPTION
We don't know yet what versions will be on the kits, however these updates are needed to unblock Python 3.11 support so it's likely that similar updates will happen there. Once we know what versions the kits will support this year we can update these again easily.

See also https://github.com/srobo/docs/issues/496

Builds on #396 for cleaner CI.