### PR TITLE
Move to importlib.metadata

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import sys
 import time
 import contextlib
+import importlib.metadata
 from typing import Iterator, TYPE_CHECKING
 from pathlib import Path
 
-import pkg_resources
 # Webots specific library
 from controller import Node, Supervisor
 
@@ -93,12 +93,15 @@ def check_required_libraries(path: Path) -> None:
         if not package:
             continue
 
+        package_name, sep, expected_version = package.partition('==')
+
         try:
-            pkg_resources.get_distribution(package)
-        except pkg_resources.DistributionNotFound:
+            actual_version = importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
             missing.append(package)
-        except pkg_resources.VersionConflict:
-            incorrect.append(package)
+        else:
+            if expected_version != actual_version:
+                incorrect.append(package)
 
     if missing or incorrect:
         raise RuntimeError(


### PR DESCRIPTION
`pkg_resources` isn't part of the standard library an is in fact deprecated. Using `importlib.metadata` is the expected replacement, and is part of the standard library. This resolves a warning that users would otherwise see when running Webots, which is likely to confuse first-time users.

Manually checked with a missing and a mismatched version of some required packages.

Fixes https://github.com/srobo/competition-simulator/issues/398