### PR TITLE
Ensure we pick up tests in the 'sr' module

### DIFF
--- a/script/testing/test
+++ b/script/testing/test
@@ -8,6 +8,9 @@ export PYTHONPATH=$PWD/stubs:$PWD/modules
 
 python3 -m unittest discover --buffer --start-directory modules "$@"
 
+# The sr module uses namespace packages and thus needs more specific searching
+python3 -m unittest discover --buffer --start-directory modules/sr "$@"
+
 for dir in ./controllers/*/
 do
     echo -e "\nTesting $dir"


### PR DESCRIPTION
It became a namespace package in 1bbf59072a94ec0e04aeff046f3457c4a70cace5, which turns out to make unittest test discovery not work.