### PR TITLE
Reinstate rejection of markers at oblique angles (and beyond)

### DIFF
--- a/controllers/test_supervisor/test_supervisor.py
+++ b/controllers/test_supervisor/test_supervisor.py
@@ -575,6 +575,23 @@ class TestCamera(unittest.TestCase):
                     "Wrong position",
                 )
 
+    def test_oblique_and_beyond_not_seen(self) -> None:
+        names = [
+            'camera-marker-oblique',
+            'camera-marker-turned-away',
+        ]
+
+        cameras = self.get_cameras(names)
+
+        for name, camera in cameras.items():
+            with self.subTest(name):
+                markers = camera.see()
+                self.assertEqual(
+                    [],
+                    markers,
+                    "Should not be able to see any markers at this angle/position",
+                )
+
 
 def main() -> None:
     global ROBOT, TIMESTEP

--- a/modules/sr/robot3/vision/api.py
+++ b/modules/sr/robot3/vision/api.py
@@ -73,7 +73,10 @@ def markers_from_objects(
     preceding_rectangles: list[Rectangle] = []
     markers = []
     for marker, image_rectangle, recognised_object in markers_with_info:
-        if not any(x.overlaps(image_rectangle) for x in preceding_rectangles):
+        if (
+            marker.is_visible_to_global_origin() and
+            not any(x.overlaps(image_rectangle) for x in preceding_rectangles)
+        ):
             markers.append((marker, recognised_object))
 
         preceding_rectangles.append(image_rectangle)

--- a/modules/sr/robot3/vision/markers.py
+++ b/modules/sr/robot3/vision/markers.py
@@ -9,7 +9,7 @@ from sr.robot3.coordinates.vectors import Vector
 DEFAULT_SIZE = 1
 
 NINETY_DEGREES = math.pi / 2
-DEFAULT_ANGLE_TOLERANCE = math.radians(75)
+DEFAULT_ANGLE_TOLERANCE = math.radians(80)
 
 
 class FiducialMarker:

--- a/modules/sr/robot3/vision/markers.py
+++ b/modules/sr/robot3/vision/markers.py
@@ -80,6 +80,37 @@ class FiducialMarker:
             vectors.ZERO_3VECTOR,
         ))
 
+    def centre_global(self) -> Vector:
+        """
+        The position of the centre of the marker, relative to the same origin as
+        used to define the general position of the marker.
+        """
+        corners = self.corners_global().values()
+        assert len(corners) == 4
+        normal = sum(corners, vectors.ZERO_3VECTOR)
+        return normal / 4
+
+    def angle_to_global_origin(self) -> float:
+        direction_to_origin = -self.centre_global()
+        normal = self.normal()
+        return vectors.angle_between(direction_to_origin, normal)
+
+    def is_visible_to_global_origin(
+        self,
+        angle_tolerance: float = DEFAULT_ANGLE_TOLERANCE,
+    ) -> bool:
+        if angle_tolerance > NINETY_DEGREES:
+            raise ValueError(
+                "Refusing to allow faces with angles > 90° to be visible "
+                "(asked for {} radians, {})".format(
+                    angle_tolerance,
+                    math.degrees(angle_tolerance),
+                ),
+            )
+
+        angle_to_origin = self.angle_to_global_origin()
+        return abs(angle_to_origin) < angle_tolerance
+
     def top_midpoint(self) -> Vector:
         """
         The midpoint of the edge which the marker determines to be the "top"

--- a/worlds/Tests.wbt
+++ b/worlds/Tests.wbt
@@ -183,6 +183,17 @@ Robot {
       translation 0 21 0
     }
     # END_GENERATED:CAMERAS
+    ## Oblique angle rejection
+    SRCamera {
+      name "camera-marker-oblique"
+      translation 0.9 -1 0
+      rotation 0 0 1 1.4835298641951802  # 85 degrees
+    }
+    SRCamera {
+      name "camera-marker-turned-away"
+      translation 2 -0.5 0
+      rotation 0 0 1 2.792526803190927  # 160 degrees
+    }
   ]
   name "test-supervisor"
   model "TestSupervisor"


### PR DESCRIPTION
Webots provides us with information about every object in front of the camera, regardless of which way the object is facing. Since we're emulating a fiducial marker system we need to filter out some of these markers, specifically in cases where:

- the marker is facing away from the camera
- the angle between the marker and the camera is too great and we expect that the vision system would not be able to recognise the marker from the pixels available

This also tunes the system to allow slightly larger angles than we've allowed in the past since the SR2024 kit is better at this than past years' were.