### PR TITLE
Couple of small vision related fixes

### DIFF
--- a/protos/Components/SRCamera.proto
+++ b/protos/Components/SRCamera.proto
@@ -46,7 +46,7 @@ PROTO SRCamera [
     height 600
     recognition Recognition {
       frameThickness 2
-      maxRange 4
+      maxRange 6
     }
   }
 }

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -114,7 +114,7 @@ Solid {  # Wall markers
     WallMarker {
       translation 2.154 -2.8749 0.175
       rotation 0 0 1 -1.5708
-      name "F0"
+      name "A0"
       model "F0"
       texture_url [
         "../textures/arena-markers/0.png"


### PR DESCRIPTION
- Bump the max camera range to 6m since the SR2024 kit is better than in the past (fixes https://github.com/srobo/competition-simulator/issues/418)
- Fix the name of the 0th arena marker (fixes https://github.com/srobo/competition-simulator/issues/419)

For merge once #415 and #420 are merged.