### PR TITLE
Import our new standard marker sizes

### DIFF
--- a/controllers/test_supervisor/test_supervisor.py
+++ b/controllers/test_supervisor/test_supervisor.py
@@ -114,7 +114,7 @@ class TestCamera(unittest.TestCase):
             [
                 Marker(
                     id=2,
-                    size=200,
+                    size=150,
                     position=Position(
                         distance=1000,
                         horizontal_angle=ApproximateFloat(0),

--- a/modules/sr/robot3/camera.py
+++ b/modules/sr/robot3/camera.py
@@ -14,7 +14,7 @@ from sr.robot3.coordinates import Position
 
 from .utils import maybe_get_robot_device
 
-MARKER_MODEL_RE = re.compile(r'^F(?P<id>\d{1,2})$')
+MARKER_MODEL_RE = re.compile(r'^F(?P<id>\d{1,3})$')
 
 
 class MarkerInfo(NamedTuple):
@@ -30,8 +30,9 @@ class MarkerInfo(NamedTuple):
 
 
 MARKER_SIZES: dict[Container[int], int] = {
-    range(28): 200,  # 0 - 27 for arena boundary
-    range(28, 100): 100,  # Everything else is a token
+    range(50): 150,  # 0-49 = 150mm
+    range(50, 100): 200,  # 50-99 = 200mm
+    range(100, 200): 80,  # 100-199 = 80mm
 }
 
 

--- a/protos/Markers/MarkerBase.proto
+++ b/protos/Markers/MarkerBase.proto
@@ -5,9 +5,9 @@ PROTO MarkerBase [
   field SFRotation rotation 0 1 0 0
   # Marker sizes are assumed to be flat squares. If this changes, or the
   # dimension which is the "thin" one changes, then changes will be needed in
-  # our vision wrappers (see `modules/sr/robot3/vision/markers.py`).
-  field SFVec3f {0.0001 0.08 0.08, 0.0001 0.2 0.2, 0.0001 0.25 0.25} visual_size 0.0001 0.08 0.08
-  field SFVec3f {0.0001 0.1 0.1, 0.0001 0.2 0.2, 0.0001 0.25 0.25} size 0.0001 0.1 0.1
+  # our vision wrappers (see `modules/sr/robot3/vision/markers.py` and
+  # `modules/sr/robot3/camera.py`).
+  field SFVec3f {0.0001 0.08 0.08, 0.0001 0.15 0.15, 0.0001 0.2 0.2} size 0.0001 0.08 0.08
   field SFString name ""
   field SFString model ""
   field MFString texture_url []
@@ -29,7 +29,7 @@ PROTO MarkerBase [
           metalness 0
         }
         geometry DEF MARKER_GEOMETRY Box {
-          size IS visual_size
+          size IS size
         }
       }
     ]

--- a/protos/Markers/TokenMarker.proto
+++ b/protos/Markers/TokenMarker.proto
@@ -19,7 +19,6 @@ PROTO TokenMarker [
     # physics and apparently that should be fine (and it does seem to work), but
     # it would likely confuse competitors to get a bunch of warnings.
     physics Physics {}
-    size 0.0001 0.1 0.1
-    visual_size 0.0001 0.08 0.08
+    size 0.0001 0.08 0.08
   }
 }

--- a/protos/Markers/WallMarker.proto
+++ b/protos/Markers/WallMarker.proto
@@ -16,7 +16,6 @@ PROTO WallMarker [
     name IS name
     model IS model
     texture_url IS texture_url
-    size 0.0001 0.2 0.2
-    visual_size 0.0001 0.2 0.2
+    size 0.0001 0.15 0.15
   }
 }


### PR DESCRIPTION
These are standard sizes which are independent of the game being run, which should avoid needing to update this part of the simulator for each year's game.

Values from https://github.com/srobo/sr-robot/blob/a1c7d2e5f21d1d482d2b2ff1d99110865ecb392e/sr/robot3/game_specific.py#L7-L11

Fixes https://github.com/srobo/competition-simulator/issues/417