### PR TITLE
Express coupling between these arguments via types

### DIFF
--- a/modules/sr/robot3/arduino_devices.py
+++ b/modules/sr/robot3/arduino_devices.py
@@ -159,7 +159,7 @@ class NullDevice(Device):
     """
 
     def analogue_read(self) -> float:
-        return map_to_range(0, 1, *Pin._ANALOGUE_RANGE, random.random())
+        return map_to_range((0, 1), Pin._ANALOGUE_RANGE, random.random())
 
     def digital_write(self, value: bool) -> None:
         pass
@@ -181,9 +181,8 @@ class DistanceSensor(Device):
 
     def analogue_read(self) -> float:
         return map_to_range(
-            self.webot_sensor.getMinValue(),
-            self.webot_sensor.getMaxValue(),
-            *Pin._ANALOGUE_RANGE,
+            (self.webot_sensor.getMinValue(), self.webot_sensor.getMaxValue()),
+            Pin._ANALOGUE_RANGE,
             self.webot_sensor.getValue(),
         )
 

--- a/modules/sr/robot3/motor.py
+++ b/modules/sr/robot3/motor.py
@@ -28,10 +28,8 @@ def translate(sr_speed_val: float, sr_motor: Gripper | Wheel | LinearMotor) -> f
         sr_speed_val = add_jitter(sr_speed_val, -SPEED_MAX, SPEED_MAX)
 
     return map_to_range(
-        -SPEED_MAX,
-        SPEED_MAX,
-        -sr_motor.max_speed,
-        sr_motor.max_speed,
+        (-SPEED_MAX, SPEED_MAX),
+        (-sr_motor.max_speed, sr_motor.max_speed),
         sr_speed_val,
     )
 

--- a/modules/sr/robot3/servos.py
+++ b/modules/sr/robot3/servos.py
@@ -53,9 +53,7 @@ class ServoDevice:
             )
 
         self.webot_motor.setPosition(map_to_range(
-            -1,
-            1,
-            self.min_position + 0.001,
-            self.max_position - 0.001,
+            (-1, 1),
+            (self.min_position + 0.001, self.max_position - 0.001),
             position,
         ))

--- a/modules/sr/robot3/utils.py
+++ b/modules/sr/robot3/utils.py
@@ -9,13 +9,13 @@ TDevice = TypeVar('TDevice', bound=Device)
 
 
 def map_to_range(
-    old_min: float,
-    old_max: float,
-    new_min: float,
-    new_max: float,
+    old_min_max: tuple[float, float],
+    new_min_max: tuple[float, float],
     value: float,
 ) -> float:
     """Maps a value from within one range of inputs to within a range of outputs."""
+    old_min, old_max = old_min_max
+    new_min, new_max = new_min_max
     return ((value - old_min) / (old_max - old_min)) * (new_max - new_min) + new_min
 
 


### PR DESCRIPTION
This also encourages callers to express their constant ranges as tuple constants, which should further clarify that they're coupled.

Builds on #412.