### PR TITLE
Move marker angle rejection test case away from others

### DIFF
--- a/controllers/test_supervisor/test_supervisor.py
+++ b/controllers/test_supervisor/test_supervisor.py
@@ -602,12 +602,20 @@ class TestCamera(unittest.TestCase):
                 )
 
     def test_oblique_and_beyond_not_seen(self) -> None:
+        CONTROL = 'camera-marker-oblique-control'
         names = [
             'camera-marker-oblique',
             'camera-marker-turned-away',
         ]
 
-        cameras = self.get_cameras(names)
+        cameras = self.get_cameras(names + [CONTROL])
+
+        control_camera = cameras.pop(CONTROL)
+        self.assertEqual(
+            [3],
+            [x.id for x in control_camera.see()],
+            "Control camera failed to see marker for oblique rejection",
+        )
 
         for name, camera in cameras.items():
             with self.subTest(name):

--- a/worlds/Tests.wbt
+++ b/worlds/Tests.wbt
@@ -196,13 +196,17 @@ Robot {
     # END_GENERATED:CAMERAS
     ## Oblique angle rejection
     SRCamera {
+      name "camera-marker-oblique-control"
+      translation 0 0 2
+    }
+    SRCamera {
       name "camera-marker-oblique"
-      translation 0.9 -1 0
+      translation 0.9 -1 2
       rotation 0 0 1 1.4835298641951802  # 85 degrees
     }
     SRCamera {
       name "camera-marker-turned-away"
-      translation 2 -0.5 0
+      translation 2 -0.5 2
       rotation 0 0 1 2.792526803190927  # 160 degrees
     }
   ]
@@ -683,6 +687,16 @@ Solid {
       ]
     }
     # END_GENERATED:MARKERS
+    ## Oblique angle rejection
+    WallMarker {
+      translation 1 0 3
+      rotation 0 0 1 0
+      name "A3"
+      model "F3"
+      texture_url [
+        "../textures/arena-markers/3.png"
+      ]
+    }
   ]
   name "Markers"
 }


### PR DESCRIPTION
These tests were accidentally relying on other aspects of our behaviour -- specifically our occlusion detection. Since that may be about to change we need to isolate these tests from it.