### PR TITLE
Disable physics on markers so things can't get stuck to tokens

### DIFF
--- a/modules/sr/robot3/vision/api.py
+++ b/modules/sr/robot3/vision/api.py
@@ -70,15 +70,9 @@ def markers_from_objects(
         key=lambda x: x[0].position.magnitude(),
     )
 
-    preceding_rectangles: list[Rectangle] = []
     markers = []
-    for marker, image_rectangle, recognised_object in markers_with_info:
-        if (
-            marker.is_visible_to_global_origin() and
-            not any(x.overlaps(image_rectangle) for x in preceding_rectangles)
-        ):
+    for marker, _, recognised_object in markers_with_info:
+        if marker.is_visible_to_global_origin():
             markers.append((marker, recognised_object))
-
-        preceding_rectangles.append(image_rectangle)
 
     return markers

--- a/protos/Markers/MarkerBase.proto
+++ b/protos/Markers/MarkerBase.proto
@@ -11,7 +11,6 @@ PROTO MarkerBase [
   field SFString name ""
   field SFString model ""
   field MFString texture_url []
-  field SFNode physics NULL
 ]
 {
   Solid {
@@ -35,10 +34,6 @@ PROTO MarkerBase [
     ]
     name IS name
     model IS model
-    boundingObject Box {
-      size IS size
-    }
-    physics IS physics
     locked TRUE
     recognitionColors [
       1 1 1

--- a/protos/Markers/TokenMarker.proto
+++ b/protos/Markers/TokenMarker.proto
@@ -14,11 +14,6 @@ PROTO TokenMarker [
     rotation IS rotation
     name IS name
     model IS model
-    # TokenMarkers need to have physics enabled otherwise we get a warning from
-    # Webots about them not having physics. We don't really want them to have
-    # physics and apparently that should be fine (and it does seem to work), but
-    # it would likely confuse competitors to get a bunch of warnings.
-    physics Physics {}
     size 0.0001 0.08 0.08
   }
 }


### PR DESCRIPTION
This prevents an issue where parts of the robot grabber could get stuck on the side of tokens, we believe due to the grabber getting "between" the marker and the token physics objects. Disabling the physics on the marker means we can't have a bounding box there, which in turn means the visible bounds of the recognition objects are quite a bit wider than they ought to be.

Happily that doesn't affect the parts of the vision data that we present to competitors. It does affect our occlusion logic though, meaning that we need to disable that. From what I can recall our inclusion of that was a workaround for recognition objects being visible through other recognition objects, which is not an issue now that we have distinct entities for the recognition objects (i.e: markers) and the things they're attached to (tokens, props, etc.).

Builds on #433.