### PR TITLE
Improve self-limiting of keyboard robot inputs

### DIFF
--- a/controllers/example_controller/keyboard_controller.py
+++ b/controllers/example_controller/keyboard_controller.py
@@ -174,9 +174,12 @@ while True:
         key = keyboard.getKey()
 
     if boost:
-        # double power values but constrain to [-1, 1]
-        left_power = max(min(left_power * 2, 1), -1)
-        right_power = max(min(right_power * 2, 1), -1)
+        left_power *= 2
+        right_power *= 2
+
+    # constrain to [-1, 1] to avoid errors
+    left_power = max(min(left_power, 1), -1)
+    right_power = max(min(right_power, 1), -1)
 
     robot.motor_board.motors[0].power = left_power
     robot.motor_board.motors[1].power = right_power


### PR DESCRIPTION
I've occasionally seen errors from non-boosted inputs which appear to be too large for the motors to handle. The code seems to allow that to happen if there's more than one input character in the buffer. Clamping all inputs (not just boosted ones) should make these errors impossible.