### PR TITLE
Allow LEDs to be toggled at the start of the match

### DIFF
--- a/modules/sr/robot3/output_frequency_limiter.py
+++ b/modules/sr/robot3/output_frequency_limiter.py
@@ -11,7 +11,8 @@ MIN_TIME_BETWEEN_CHANGES = 1 / MAX_FREQUENCY
 class OutputFrequencyLimiter:
     def __init__(self, webot: Robot) -> None:
         self._webot = webot
-        self._last_change: float = 0
+        # Allow the first change to happen immediately
+        self._last_change: float = -MIN_TIME_BETWEEN_CHANGES
 
     def can_change(self) -> bool:
         now = self._webot.getTime()


### PR DESCRIPTION
Currently LEDs cannot be adjusted for the first 0.5 seconds.

Fixes #444 