### PR TITLE
Remove unused robots in dev mode too

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -209,8 +209,6 @@ def run_match(supervisor: Supervisor) -> None:
 
 
 def main() -> None:
-    quit_if_development_mode()
-
     controller_utils.tee_streams(
         controller_utils.get_competition_supervisor_log_filepath(),
     )
@@ -219,6 +217,7 @@ def main() -> None:
 
     with propagate_exit_code(supervisor):
         remove_unused_robots(supervisor)
+        quit_if_development_mode()
         wait_until_robots_ready(supervisor)
 
         set_simulation_mode(supervisor, Supervisor.SIMULATION_MODE_PAUSE)


### PR DESCRIPTION
I'm not entirely sure what the side-effects are of reordering these events, advice would be more than welcome!

But the benefits of this is my simulator runs at 5x speed with 1 robot in the arena, and 3x speed with 4 robots in the arena, so it's about a 66% simulation speed improvement