### PR TITLE
Improve windows support around run-comp-match

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Define scripts to test
         id: define_scripts
         run: |
-          SCRIPTS=$(find script -type f | grep -vE "/(linting/|testing/|typing/|check$)" | tr "\n" " ")
+          SCRIPTS=$(find script -type f | grep -vE "/(linting/|testing/|typing/|check$|.*\\.bat$)" | tr "\n" " ")
           echo SCRIPTS=$SCRIPTS >> $GITHUB_OUTPUT
 
       - name: Lint with flake8

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ In order to run competition matches you'll need to:
     create any issues with the rendered videos, though you are encouraged to
     check that your setup is recording the videos correctly.
 
+If `webots` is not available on `PATH` (such as on Windows by default) you can
+pass the full path to the webots executable using the `WEBOTS_EXECUTABLE`
+environment variable.
+
 ## Collecting up logs for the Discord bot
 
 The `zip-comp-logs` command allows logs to be collated into a zip with certain combinations of match animations.

--- a/script/check
+++ b/script/check
@@ -2,7 +2,7 @@
 
 cd $(dirname $0)/..
 
-SCRIPTS=$(find script -type f | grep -vE "/(linting/|testing/|typing/|check$)")
+SCRIPTS=$(find script -type f | grep -vE "/(linting/|testing/|typing/|check$|.*\\.bat$)")
 
 ./script/testing/test
 result=$?

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -103,7 +103,8 @@ def run_match() -> None:
         ])
     except FileNotFoundError:
         print_fatal(
-            "Could not find webots. Check that you have it installed and on your PATH",
+            "Could not find webots. Check that you have it installed and on your "
+            "PATH, or set WEBOTS_EXECUTABLE to the full path to the executable.",
         )
         exit(1)
     except subprocess.CalledProcessError as e:

--- a/script/run-comp-match.bat
+++ b/script/run-comp-match.bat
@@ -1,0 +1,4 @@
+rem Batch script to simplify using run-comp-match on Windows
+
+set WEBOTS_EXECUTABLE=%WEBOTS_HOME%\msys64\mingw64\bin
+python %~dp0\run-comp-match %*

--- a/script/run-comp-match.bat
+++ b/script/run-comp-match.bat
@@ -1,4 +1,4 @@
 rem Batch script to simplify using run-comp-match on Windows
 
-set WEBOTS_EXECUTABLE=%WEBOTS_HOME%\msys64\mingw64\bin
+set WEBOTS_EXECUTABLE=%WEBOTS_HOME%\msys64\mingw64\bin\webots.exe
 python %~dp0\run-comp-match %*


### PR DESCRIPTION
I'm pretty confident we want the first change here (docs)~, less sure about the second. The latter definitely needs testing by someone on Windows. I can probably do that at some point, but I don't know if I have webots setup/etc. on my Windows machine so if someone who does is able to review that before I get back to this please do so!~

Have now tested this on Windows & fixed a small issue. In my testing I didn't have the right Python packages installed so the simulation only got as far as that check, however I think that's still far enough to prove that the rest of the system worked -- it was able to execute Python to run the match script, which found Webots via `WEBOTS_EXECUTABLE` which was subsequently able to launch Python to run the "user" code.

Testing was based on a manually taken copy of the batch script dropped into an existing copy I had of the sr2024.1 release.